### PR TITLE
docs(v0.2.1): mark v0.2.0 released + strip local-document references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] — 2026-05-27
+
+Docs-only patch. No runtime behavior changed.
+
+### Fixed
+- README Status row now says "v0.2.0 — released on PyPI" instead of "v0.2.0 (in progress)" — the v0.2.0 PR landed before the tag pushed, leaving the row stale.
+- README + ROADMAP no longer link to internal working-state documents. The Status row and Released row now stand on their own one-line summary instead of pointing readers at maintainer-only spec files that wouldn't render for someone browsing only the published surface.
+- ROADMAP v0.2.0 row marked as released (2026-05-27).
+- `unpack_flux2_latent` docstring no longer references a maintainer working note. Users were seeing the broken pointer in IDE tooltips when hovering the function in VS Code.
+
 ## [0.2.0] — 2026-05-27
 
 Substantial release. Auto-bn extraction makes FLUX.2 live previews color-correct by default; the showcase bench publishes measured timings + perceptual fidelity numbers anyone can reproduce.

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ See `docs/manual-verification.md` for the full verification recipe.
 ## Status
 
 - **v0.1.0 — initial public release on PyPI** (2026-05-13). All four variants, encoder + decoder, mflux integration, CI, 99 % honest coverage.
-- **v0.2.0** *(in progress)* — auto-bn extraction in `LivePreviewCallback(flux=...)`; per-step gallery mode (`numbered_frames=True`); subprocess-per-rep showcase bench (`scripts/run_showcase.py`); hardware-aware memory caps via `mlx_taef._memory_caps`; `COMPARISON.md` + committed JSON report; `ROADMAP.md`. See [`docs/superpowers/specs/2026-05-26-mlx-taef-v0.2.0-design.md`](docs/superpowers/specs/2026-05-26-mlx-taef-v0.2.0-design.md).
+- **v0.2.0 — released on PyPI** (2026-05-27). Auto-bn extraction in `LivePreviewCallback(flux=...)`; per-step gallery mode (`numbered_frames=True`); subprocess-per-rep showcase bench (`scripts/run_showcase.py`); hardware-aware memory caps via `mlx_taef._memory_caps`; [COMPARISON.md](COMPARISON.md) + committed JSON report; [ROADMAP.md](ROADMAP.md).
 
 Track future releases via the [PyPI history](https://pypi.org/project/mlx-taef/#history) or `gh release list -R IonDen/mlx-taef`.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ A non-binding sketch of where the library is headed. Each item lists status, eff
 
 ## Released
 
-- **v0.2.0** *(in progress)* — `LivePreviewCallback` auto-bn extraction for taef2; `COMPARISON.md` + `scripts/run_showcase.py` measured showcase (4 scenarios); subprocess-per-rep `scripts/bench_decode.py`; per-variant `memory_cap_hint_gb` + `FULL_VAE_CAP_GB`; session-level `tests/conftest.py` MLX cap; `ROADMAP.md`; cross-process MLX non-determinism caveat in `docs/manual-verification.md`; Trove classifier alignment; `showcase` runtime extra. See `docs/superpowers/specs/2026-05-26-mlx-taef-v0.2.0-design.md` for the design.
+- **v0.2.0** (2026-05-27) — `LivePreviewCallback` auto-bn extraction for taef2; [COMPARISON.md](COMPARISON.md) + `scripts/run_showcase.py` measured showcase (4 scenarios); subprocess-per-rep `scripts/bench_decode.py`; per-variant `memory_cap_hint_gb` + `FULL_VAE_CAP_GB`; session-level `tests/conftest.py` MLX cap; cross-process MLX non-determinism caveat in [docs/manual-verification.md](docs/manual-verification.md); Trove classifier alignment; `showcase` runtime extra.
 - **v0.1.1** (2026-05-13) — sha256 sidecars on committed fixtures; SSIM ≥ 0.75 perceptual contract on roundtrip; release workflow ships a GitHub Release on tag push.
 - **v0.1.0** (2026-05-13) — initial public release. 4 variants (TAESD, TAESDXL, TAEF1, TAEF2) with one consistent API. mflux `LivePreviewCallback`. 99-100% coverage.
 

--- a/src/mlx_taef/integrations/mflux.py
+++ b/src/mlx_taef/integrations/mflux.py
@@ -60,8 +60,6 @@ def unpack_flux2_latent(
     Returns:
         NHWC tensor of shape (B, latent_height*2, latent_width*2, 32) — ready
         for `TAEF2.decode()`.
-
-    See `notes/mflux-latent-layout.md` for the analysis behind this transform.
     """
     b, _, c = packed.shape
     if c != 128:


### PR DESCRIPTION
## Summary

Two small post-v0.2.0 cleanups, both surfaced by user review:

1. **README/ROADMAP Status rows still said "v0.2.0 (in progress)"** because the wording was written while the v0.2.0 PR was open and not flipped after the tag pushed. Both rows now reflect the release.
2. **Three references to maintainer working documents** were leaking onto the user-facing surface (README link, ROADMAP link, and an `unpack_flux2_latent` docstring pointing at a working note that shows up in IDE tooltips). All three removed; replaced with one-line summaries in place.

Codifies the rule in global CLAUDE.md: public-facing files must not link to or reference paths under `docs/superpowers/`, internal `notes/`, or any working-state document the user-facing surface doesn't expose.

## Scope

Docs-only. No runtime behavior changed. 158 tests still pass; ruff + mypy clean (the persistent `_version.py` warning is on an auto-generated git-ignored file).

## Test plan

- [x] `uv run pytest` — 158 passed
- [x] `uv run mypy src/mlx_taef` — clean
- [x] `grep -rE 'docs/superpowers|(^| |\(|\`)notes/[a-z]' README.md CHANGELOG.md COMPARISON.md ROADMAP.md src/` returns zero hits

## Release notes (v0.2.1 — 2026-05-27)

Docs-only patch. See `CHANGELOG.md` for the four bullets.