### PR TITLE
v0.2.2 — discoverability sweep (metadata + LICENSE + examples + README decision section)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] — 2026-05-27
+
+Discoverability sweep. No runtime behavior changed; this release is a docs + metadata patch.
+
+### Added
+- `LICENSE` file at the repo root (MIT). The pyproject already declared `license = "MIT"` but the file itself was never committed, so GitHub's license auto-detect returned null and the README badge URL 404'd. Fixed.
+- `examples/` directory with three runnable scripts:
+  - `decode_flux_latent.py` — load a committed showcase latent, decode with TAEF2, write `out.webp`. Non-mflux use case.
+  - `mflux_live_preview.py` — Flux2Klein + LivePreviewCallback with `flux=model` auto-bn. The headline integration.
+  - `mflux_combined_with_teacache.py` — same as live_preview, also wrapped with `apply_teacache`. Combined-use story.
+- README "Which library do I need?" section directly under the intro. Three-paragraph decision tree that converts arrivals from need-based searches.
+
+### Changed
+- PyPI `description` aligned with the GitHub repo description: now names live previews + low-memory decode + FLUX & SD targets instead of the previous generic "TAESD family on Apple MLX" framing.
+- PyPI `keywords` expanded 6 → 14 (added `apple-silicon`, `diffusion`, `mflux`, `taef`, `taef1`, `taef2`, `tiny-autoencoder`, `vae`, `latent-preview`) so need-based PyPI search returns this package.
+- PyPI `project.urls` adds `Source`, `Comparison`, and `Roadmap` entries pointing at the committed docs on `main`.
+
+### Fixed
+- PyPI `Documentation` URL removed (was pointing at `ionden.github.io/mlx-taef`, which returns HTTP 404). Replaced with the new `Source` / `Comparison` / `Roadmap` URLs that all resolve.
+- README badge `License: MIT` now resolves (was 404 because the LICENSE file was missing — see Added above).
+
 ## [0.2.1] — 2026-05-27
 
 Docs-only patch. No runtime behavior changed.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Denis Ineshin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ img = taef.decode(latents)                  # NHWC float in [0, 1]
 img_uint8 = taef.decode_image(latents)      # uint8 NHWC ready for PIL
 ```
 
+## Which library do I need?
+
+**You want live previews or low-memory FLUX decode?** You're in the right place. `mlx-taef` decodes diffusion latents to RGB in ~260 ms (TAEF2) or ~185 ms (TAEF1) on M1 Max — vs ~2 seconds for the full VAE, with ~4× less peak memory. Drops into mflux via `LivePreviewCallback`.
+
+**You want FLUX generation itself to be faster on Apple Silicon?** You want [`mlx-teacache`](https://github.com/IonDen/mlx-teacache) — it skips redundant denoising steps when the schedule is cacheable (measured 1.44× on FLUX.1-dev at 25 steps).
+
+**You want both: faster generation AND live previews?** Use them together — they compose cleanly. mflux 4-step Klein + TeaCache + TAEF2 previews = 1.30× wall-clock and 26% less peak memory vs vanilla.
+
 ## Install
 
 From PyPI:

--- a/examples/decode_flux_latent.py
+++ b/examples/decode_flux_latent.py
@@ -1,0 +1,58 @@
+"""Decode a FLUX latent with TAEF2 (no mflux generation needed).
+
+Target search query: "decode FLUX latents MLX", "TAEF2 standalone".
+Expected output: writes `out.webp` (512x512 RGB) next to this script.
+
+Run with:
+    uv run python examples/decode_flux_latent.py
+
+Loads the committed showcase latent fixture
+(tests/fixtures/showcase_latents/flux2_klein_base_4b.safetensors),
+unpacks it via the mflux integration helper, and decodes with TAEF2.
+Demonstrates the non-mflux entry point — useful for offline latent
+inspection or pipeline integration without running the full diffusion
+loop.
+"""
+
+from pathlib import Path
+
+import mlx.core as mx
+import numpy as np
+from PIL import Image
+
+from mlx_taef import TAEF2
+from mlx_taef.integrations.mflux import unpack_flux2_latent
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FIXTURE = REPO_ROOT / "tests" / "fixtures" / "showcase_latents" / "flux2_klein_base_4b.safetensors"
+OUT_PATH = Path(__file__).resolve().parent / "out.webp"
+
+
+def main() -> None:
+    print(f"loading fixture: {FIXTURE}")
+    arrays = mx.load(str(FIXTURE))
+    latent = arrays["latent"]
+    height = int(arrays["height"].item())
+    width = int(arrays["width"].item())
+    bn_mean = arrays["bn_mean"]
+    bn_var = arrays["bn_var"]
+    print(f"  latent shape: {latent.shape}, target image: {height}x{width}")
+
+    print("unpacking + decoding with TAEF2...")
+    taef = TAEF2.from_pretrained(include_encoder=False)
+    nhwc = unpack_flux2_latent(
+        latent,
+        latent_height=height // 16,
+        latent_width=width // 16,
+        bn_mean=bn_mean,
+        bn_var=bn_var,
+    )
+    img_uint8 = taef.decode_image(nhwc)
+    mx.eval(img_uint8)
+
+    Image.fromarray(np.array(img_uint8[0])).save(OUT_PATH, "WEBP", quality=92)
+    print(f"wrote {OUT_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/mflux_combined_with_teacache.py
+++ b/examples/mflux_combined_with_teacache.py
@@ -1,0 +1,72 @@
+"""mflux + mlx-teacache + TAEF2 live preview — combined-use story.
+
+Target search query: "mflux teacache taef", "fast FLUX previews Mac",
+"combined Apple Silicon FLUX speedup".
+
+Expected output: writes `combined_step{NN}.png` frames + a
+`combined_final.webp` next to this script. Also prints the TeaCache
+skip count after generation so users can see when step-skipping
+actually fires.
+
+Run with:
+    uv run python examples/mflux_combined_with_teacache.py
+
+Generates the same 4-step Flux2Klein image as the live_preview
+example but wraps the transformer with mlx-teacache's apply_teacache
+first. The two libraries compose cleanly — neither knows about the
+other. Requires mlx-teacache >= 0.6 (installed via the [showcase]
+extra: `pip install 'mlx-taef[showcase]'`).
+"""
+
+from pathlib import Path
+
+from mflux.models.common.config.model_config import ModelConfig
+from mflux.models.flux2.variants.txt2img.flux2_klein import Flux2Klein
+from mlx_teacache import apply_teacache
+
+from mlx_taef.integrations.mflux import LivePreviewCallback
+
+OUT_DIR = Path(__file__).resolve().parent
+
+
+def main() -> None:
+    print("loading Flux2Klein base 4B (quantize=4)...")
+    model = Flux2Klein(quantize=4, model_config=ModelConfig.flux2_klein_base_4b())
+
+    print("wrapping with mlx-teacache...")
+    handle = apply_teacache(model)
+
+    callback = LivePreviewCallback(
+        flux=model,
+        variant="taef2",
+        every=1,
+        numbered_frames=True,
+        save_to=OUT_DIR / "combined.png",
+        latent_height=32,
+        latent_width=32,
+    )
+    model.callbacks.register(callback)
+
+    print("generating: 'a red apple on a wooden table', 4 steps + TeaCache, seed=42...")
+    generated = model.generate_image(
+        seed=42,
+        prompt="a red apple on a wooden table",
+        num_inference_steps=4,
+        width=512,
+        height=512,
+        guidance=1.0,
+    )
+
+    final_path = OUT_DIR / "combined_final.webp"
+    generated.image.save(final_path, "WEBP", quality=92)
+
+    print(
+        f"wrote {len(callback.saved_paths)} preview frames + {final_path}\n"
+        f"TeaCache stats: skipped={handle.stats.skipped_count}, "
+        f"computed={handle.stats.computed_count}, "
+        f"variant={getattr(handle, 'variant_id', 'unknown')}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/mflux_live_preview.py
+++ b/examples/mflux_live_preview.py
@@ -1,0 +1,65 @@
+"""mflux live preview with TAEF2 — headline integration.
+
+Target search query: "mflux live preview", "FLUX2 preview mlx",
+"FLUX live preview Mac".
+
+Expected output: writes preview frames as `preview_step{NN}.png`
+next to this script, plus the final mflux-generated image as
+`preview_final.webp`. With auto-bn enabled (default), previews
+are color-correct from step 1.
+
+Run with:
+    uv run python examples/mflux_live_preview.py
+
+Generates a 4-step FLUX.2 Klein base 4B image at 512x512 with a
+TAEF2 live-preview callback. Demonstrates the auto-bn extraction
+flow added in v0.2.0: pass `flux=model` and the callback walks
+`model.vae.bn.running_mean / running_var` automatically.
+"""
+
+from pathlib import Path
+
+from mflux.models.common.config.model_config import ModelConfig
+from mflux.models.flux2.variants.txt2img.flux2_klein import Flux2Klein
+
+from mlx_taef.integrations.mflux import LivePreviewCallback
+
+OUT_DIR = Path(__file__).resolve().parent
+
+
+def main() -> None:
+    print("loading Flux2Klein base 4B (quantize=4)...")
+    model = Flux2Klein(quantize=4, model_config=ModelConfig.flux2_klein_base_4b())
+
+    callback = LivePreviewCallback(
+        flux=model,
+        variant="taef2",
+        every=1,
+        numbered_frames=True,
+        save_to=OUT_DIR / "preview.png",
+        latent_height=32,
+        latent_width=32,
+    )
+    print(f"  resolved_bn = {callback.resolved_bn}  (expect 'auto')")
+    assert callback.resolved_bn == "auto", "auto-bn extraction failed; check flux.vae.bn"
+
+    model.callbacks.register(callback)
+
+    print("generating: 'a red apple on a wooden table', 4 steps, seed=42...")
+    generated = model.generate_image(
+        seed=42,
+        prompt="a red apple on a wooden table",
+        num_inference_steps=4,
+        width=512,
+        height=512,
+        guidance=1.0,
+    )
+
+    final_path = OUT_DIR / "preview_final.webp"
+    generated.image.save(final_path, "WEBP", quality=92)
+
+    print(f"wrote {len(callback.saved_paths)} preview frames + {final_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,16 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mlx-taef"
-description = "Tiny AutoEncoders for diffusion (TAESD family) on Apple MLX."
+description = "Tiny AutoEncoders for diffusion on Apple Silicon — live previews + low-memory decode for FLUX & SD."
 readme = "README.md"
 requires-python = ">=3.11"
 license = "MIT"
 authors = [{ name = "Denis Ineshin", email = "denis.ineshin@gmail.com" }]
-keywords = ["mlx", "stable-diffusion", "flux", "autoencoder", "taesd", "apple-silicon"]
+keywords = [
+  "mlx", "apple-silicon", "diffusion", "stable-diffusion",
+  "flux", "mflux", "taesd", "taef", "taef1", "taef2",
+  "tiny-autoencoder", "vae", "latent-preview", "autoencoder",
+]
 classifiers = [
   "Development Status :: 4 - Beta",
   "Environment :: MacOS X",
@@ -44,10 +48,12 @@ showcase = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/ionden/mlx-taef"
-Documentation = "https://ionden.github.io/mlx-taef"
-Issues = "https://github.com/ionden/mlx-taef/issues"
-Changelog = "https://github.com/ionden/mlx-taef/blob/main/CHANGELOG.md"
+Homepage = "https://github.com/IonDen/mlx-taef"
+Source = "https://github.com/IonDen/mlx-taef"
+Issues = "https://github.com/IonDen/mlx-taef/issues"
+Changelog = "https://github.com/IonDen/mlx-taef/blob/main/CHANGELOG.md"
+Comparison = "https://github.com/IonDen/mlx-taef/blob/main/COMPARISON.md"
+Roadmap = "https://github.com/IonDen/mlx-taef/blob/main/ROADMAP.md"
 
 [project.scripts]
 mlx-taef = "mlx_taef.cli:main"


### PR DESCRIPTION
## Summary

Applies §1 of the discoverability sweep design across `mlx-taef`. Six grouped changes:

- **LICENSE file** at the repo root (MIT) — fixes the missing file that was making `repos/IonDen/mlx-taef` show `license: null` via GitHub API and 28% community-health score. README badge now resolves.
- **PyPI metadata aligned**: `description` matches the GitHub repo description, `keywords` expanded 6 → 14, `project.urls` adds `Source`/`Comparison`/`Roadmap`, dead `Documentation` URL removed.
- **README "Which library do I need?" section** right under the intro — three-paragraph decision tree cross-linking `mlx-teacache`.
- **examples/ directory** with three runnable scripts: `decode_flux_latent.py` (non-mflux), `mflux_live_preview.py` (headline integration), `mflux_combined_with_teacache.py` (combined story).
- **CHANGELOG `[0.2.2]` entry**.

No runtime behavior change. No new tests (examples are documentation that runs).

Companion PR in `mlx-teacache` lands the mirror changes (PyPI metadata + Trove bump + README cross-reference + three examples): https://github.com/IonDen/mlx-teacache/pull/12

## Test plan

- [x] `grep -nE 'docs/superpowers|...' README.md CHANGELOG.md COMPARISON.md ROADMAP.md src/ examples/` returns zero hits
- [x] `uv run ruff check .` and `uv run ruff format --check .` pass
- [x] `uv run mypy src/mlx_taef` passes
- [x] `uv run pytest -q` passes (no new tests, count unchanged)
- [x] `uv build --sdist` produces a valid sdist with the new metadata visible in PKG-INFO
- [x] `examples/*.py` files smoke-import cleanly

## Post-merge actions

1. Set GitHub topics via `gh api -X PUT repos/IonDen/mlx-taef/topics ...` (requires explicit user authorization — public metadata change).
2. Tag `v0.2.2` (requires explicit user authorization — triggers PyPI Trusted Publishing).