### PR TITLE
chore: add author footer linking ineshin.space

### DIFF
--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -112,8 +112,8 @@ Every number on this page ties to a measurement in the committed JSON at `_artif
 
 The headline `~8.3×` and `~10.8×` numbers are for the decoder step *in isolation*, on the same latent, in cold subprocesses. They are NOT whole-generation speedups — for that, look at the `combined` scenario, which shows what users see when they pair TAEF previews with TeaCache step-skipping. The decoder speedup matters most for live previews — every step is a separate decode, and you pay it once per step.
 
+SSIM thresholds: the 0.75 figure in the spec was a starting heuristic. The first bench run validates it; the regression check locks the floor at `ssim_median - 0.05` from v0.2.1 forward. TAEF2's 0.616 is genuinely lower than that heuristic. That's a signal of upstream TAEF2's preview-grade fidelity, not a regression in mlx-taef's port.
+
 ---
 
 By Denis Ineshin · [ineshin.space](https://ineshin.space)
-
-SSIM thresholds: the 0.75 figure in the spec was a starting heuristic. The first bench run validates it; the regression check locks the floor at `ssim_median - 0.05` from v0.2.1 forward. TAEF2's 0.616 is genuinely lower than that heuristic. That's a signal of upstream TAEF2's preview-grade fidelity, not a regression in mlx-taef's port.

--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -112,4 +112,8 @@ Every number on this page ties to a measurement in the committed JSON at `_artif
 
 The headline `~8.3×` and `~10.8×` numbers are for the decoder step *in isolation*, on the same latent, in cold subprocesses. They are NOT whole-generation speedups — for that, look at the `combined` scenario, which shows what users see when they pair TAEF previews with TeaCache step-skipping. The decoder speedup matters most for live previews — every step is a separate decode, and you pay it once per step.
 
+---
+
+By Denis Ineshin · [ineshin.space](https://ineshin.space)
+
 SSIM thresholds: the 0.75 figure in the spec was a starting heuristic. The first bench run validates it; the regression check locks the floor at `ssim_median - 0.05` from v0.2.1 forward. TAEF2's 0.616 is genuinely lower than that heuristic. That's a signal of upstream TAEF2's preview-grade fidelity, not a regression in mlx-taef's port.

--- a/README.md
+++ b/README.md
@@ -125,4 +125,9 @@ MIT. Mirrors upstream [madebyollin/taesd](https://github.com/madebyollin/taesd) 
 
 - [madebyollin](https://github.com/madebyollin) for the upstream TAESD-family models and weights.
 - [Apple ML Explore](https://github.com/ml-explore/mlx) for MLX.
+
+---
+
+By Denis Ineshin · [ineshin.space](https://ineshin.space)
+
 - [filipstrand/mflux](https://github.com/filipstrand/mflux) for the MLX-native FLUX runner this library integrates with.

--- a/README.md
+++ b/README.md
@@ -125,9 +125,8 @@ MIT. Mirrors upstream [madebyollin/taesd](https://github.com/madebyollin/taesd) 
 
 - [madebyollin](https://github.com/madebyollin) for the upstream TAESD-family models and weights.
 - [Apple ML Explore](https://github.com/ml-explore/mlx) for MLX.
+- [filipstrand/mflux](https://github.com/filipstrand/mflux) for the MLX-native FLUX runner this library integrates with.
 
 ---
 
 By Denis Ineshin · [ineshin.space](https://ineshin.space)
-
-- [filipstrand/mflux](https://github.com/filipstrand/mflux) for the MLX-native FLUX runner this library integrates with.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,4 +42,9 @@ The mlx-taef integration cost for each is roughly: half-day of code (new variant
 1. **Active items first.** Items under `## Active` are committed. Finish current Active item before pulling the next in.
 2. **Future improvements next.** Items under `## Future improvements` are pre-vetted improvement ideas. Each can be lifted into an Active release.
 3. **Known-upstream variants are a menu, not a queue.** Pick from it based on community demand + bench cost.
+
+---
+
+By Denis Ineshin · [ineshin.space](https://ineshin.space)
+
 4. **Out of scope is durable.** Re-opening an item there requires evidence that the original reasoning no longer holds.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,9 +42,8 @@ The mlx-taef integration cost for each is roughly: half-day of code (new variant
 1. **Active items first.** Items under `## Active` are committed. Finish current Active item before pulling the next in.
 2. **Future improvements next.** Items under `## Future improvements` are pre-vetted improvement ideas. Each can be lifted into an Active release.
 3. **Known-upstream variants are a menu, not a queue.** Pick from it based on community demand + bench cost.
+4. **Out of scope is durable.** Re-opening an item there requires evidence that the original reasoning no longer holds.
 
 ---
 
 By Denis Ineshin · [ineshin.space](https://ineshin.space)
-
-4. **Out of scope is durable.** Re-opening an item there requires evidence that the original reasoning no longer holds.


### PR DESCRIPTION
## Summary

Appends a uniform author footer to the three durable user-facing top-level docs (README, COMPARISON, ROADMAP). Closes the loop between readers landing on PyPI or the GitHub repo and Denis Ineshin's personal site at <https://ineshin.space>, where the libraries are cross-promoted alongside mlx-teacache.

## What changed

- README.md, COMPARISON.md, ROADMAP.md each gain the same trailing block:

  \`\`\`markdown


  ---

  By Denis Ineshin · [ineshin.space](https://ineshin.space)
  \`\`\`

- No CHANGELOG entry. The footer rides PyPI on the next regular release (no version bump for the footer alone).
- No source code, no tests, no examples touched.

## Verification

- \`grep -l 'ineshin\\.space' README.md COMPARISON.md ROADMAP.md\` → three files
- \`grep -nE 'docs/superpowers|^notes/' README.md CHANGELOG.md COMPARISON.md ROADMAP.md\` → zero hits (no local-only refs introduced)
- \`pytest -m "not slow and not network"\` → all tests pass locally

## Test plan

- [ ] CI green on macOS 14 ARM64
- [ ] Linux typecheck + lint pass
- [ ] Visual diff of the three files in the PR view shows only the trailing footer block added