### PR TITLE
test: gate decode/encode parity on assert_allclose, not cosine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- End-to-end decode and encode parity tests now gate on an absolute pixel/latent
+  tolerance (`np.testing.assert_allclose`) instead of cosine similarity > 0.999.
+  On the `[0, 1]` images these decoders produce, cosine similarity is DC-dominated
+  and brightness/scale-insensitive — a +0.05 brightness shift scored cosine 0.9996
+  and passed the old gate. The new gates are `atol=1e-4` for decode (measured worst
+  maxabs ~1.1e-5) and `atol=1e-3` for encode (measured worst ~2.4e-4 on taef1);
+  both use `rtol=0` because the values pass through zero. A regression test now
+  asserts the decode gate rejects a +0.05 shift.
+
 ## [0.2.2] — 2026-05-27
 
 Discoverability sweep. No runtime behavior changed; this release is a docs + metadata patch.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,6 +18,16 @@ from mlx_taef.variants import (
 CONVERTED_DIR = Path(__file__).parent / "converted"
 REF_DIR = Path(__file__).parent / "reference"
 
+# Primary decode parity tolerance. Pixel values are in [0, 1] and pass through
+# zero, so a relative tolerance is undefined near zero (measured maxrel explodes
+# to ~3.0 at near-black pixels) — we gate on absolute tolerance only. Measured
+# worst maxabs across all 4 variants x 5 fixtures is ~1.1e-5 (MLX-Metal fp32 vs
+# the PyTorch fp32 reference); 1e-4 clears that ~9x for cross-hardware fp32
+# reduction-order noise while still failing a +0.05 brightness shift by ~500x.
+# See mlx-taef-0001: a cosine-only gate (cos > 0.999) is DC-dominated on
+# mid-gray images and accepts brightness/contrast/noise regressions.
+DECODE_ATOL = 1e-4
+
 
 def _cosine_sim(a: np.ndarray, b: np.ndarray) -> float:
     af, bf = a.flatten().astype(np.float64), b.flatten().astype(np.float64)
@@ -85,7 +95,7 @@ def test_variant_decode_against_committed_reference(
     cls: type[Taef],
     config: TaesdVariantConfig,
 ) -> None:
-    """Tier 2 parity for each variant: cosine sim > 0.999 on 5 fixtures."""
+    """Tier 2 parity for each variant: absolute pixel tolerance on 5 fixtures."""
     weights_path = CONVERTED_DIR / f"{variant_name}_decoder.safetensors"
     model = cls.from_pretrained_local(weights_path)
     for i in range(5):
@@ -94,8 +104,36 @@ def test_variant_decode_against_committed_reference(
             mx.load(str(REF_DIR / f"{variant_name}_decoded_{i:03d}.safetensors"))["image"]
         )
         out = np.array(model.decode(latent))
-        sim = _cosine_sim(out, ref)
-        # Cosine similarity > 0.999 = numerically equivalent for our purposes.
-        # Reference fixtures are PyTorch fp32 outputs; MLX runs fp32 by default.
-        # Values in [0, 1], so cosine sim is tighter than atol on raw magnitudes.
-        assert sim > 0.999, f"{variant_name} fixture {i}: cos_sim={sim:.6f}"
+        # Absolute pixel tolerance is the gate (see DECODE_ATOL). Cosine
+        # similarity is reported on failure as a secondary, scale-insensitive
+        # diagnostic, not as the pass/fail criterion.
+        np.testing.assert_allclose(
+            out,
+            ref,
+            atol=DECODE_ATOL,
+            rtol=0,
+            err_msg=f"{variant_name} fixture {i}: cos_sim={_cosine_sim(out, ref):.6f}",
+        )
+
+
+def test_decode_parity_gate_rejects_brightness_shift() -> None:
+    """The decode gate must reject a +0.05 brightness shift (mlx-taef-0001).
+
+    Regression guard for the gate's strength: a +0.05 shift produces cosine
+    similarity ~0.9996 (it sailed through the old `cos > 0.999` gate) but a
+    maxabs of 0.05 — 500x the DECODE_ATOL=1e-4 bound. If someone later loosens
+    the tolerance toward 0.05, this test catches it before a real brightness /
+    scale / dropped-bias regression can slip past parity.
+    """
+    model = TAEF2.from_pretrained_local(CONVERTED_DIR / "taef2_decoder.safetensors")
+    latent = mx.load(str(REF_DIR / "taef2_latent_000.safetensors"))["latent"]
+    ref = np.array(mx.load(str(REF_DIR / "taef2_decoded_000.safetensors"))["image"])
+    out = np.array(model.decode(latent))
+
+    # The true output clears the gate ...
+    np.testing.assert_allclose(out, ref, atol=DECODE_ATOL, rtol=0)
+    # ... but a +0.05-shifted reference must not.
+    shifted_ref = np.clip(ref + 0.05, 0.0, 1.0)
+    assert _cosine_sim(out, shifted_ref) > 0.999  # old gate would have passed this
+    with pytest.raises(AssertionError):
+        np.testing.assert_allclose(out, shifted_ref, atol=DECODE_ATOL, rtol=0)

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -19,6 +19,15 @@ from mlx_taef.variants import (
 CONVERTED_DIR = Path(__file__).parent / "converted"
 REF_DIR = Path(__file__).parent / "reference"
 
+# Primary encode parity tolerance. Latents span ~±4.6 and pass through zero, so
+# (as with decode) a relative tolerance is undefined near zero — gate on atol.
+# Measured worst maxabs across the 4 variants is ~2.4e-4 (taef1; MLX-Metal fp32
+# vs PyTorch fp32). 1e-3 is the small-model full-forward fp32 tolerance and
+# clears the worst fixture ~4x for cross-hardware reduction-order noise. Note
+# the encode worst (2.4e-4) is an order of magnitude looser than decode's
+# (1.1e-5), so the two paths carry separate tolerances. See mlx-taef-0001.
+ENCODE_ATOL = 1e-3
+
 
 def _cosine_sim(a: np.ndarray, b: np.ndarray) -> float:
     af, bf = a.flatten().astype(np.float64), b.flatten().astype(np.float64)
@@ -47,7 +56,7 @@ def test_variant_encode_parity(
     cls: type[Taef],
     config: TaesdVariantConfig,
 ) -> None:
-    """Encoded latents must match PyTorch reference at cosine similarity > 0.999."""
+    """Encoded latents must match the PyTorch reference within ENCODE_ATOL."""
     model = cls.from_pretrained_local(
         decoder_path=CONVERTED_DIR / f"{variant_name}_decoder.safetensors",
         encoder_path=CONVERTED_DIR / f"{variant_name}_encoder.safetensors",
@@ -55,12 +64,15 @@ def test_variant_encode_parity(
     src = _load_source_image()
     expected = np.array(mx.load(str(REF_DIR / f"{variant_name}_encoded_001.safetensors"))["latent"])
     actual = np.array(model.encode(src))
-    sim = _cosine_sim(actual, expected)
-    # Cosine similarity > 0.999 = numerically equivalent for our purposes.
-    # Reference fixtures are PyTorch fp32 outputs; MLX runs fp32 by default
-    # (overridden to fp16 only in perf tests). Latent values can be large
-    # (roughly ±3), so cosine sim is more stable than a raw atol here.
-    assert sim > 0.999, f"{variant_name}: encode cos_sim={sim:.6f}"
+    # Absolute latent tolerance is the gate (see ENCODE_ATOL). Cosine similarity
+    # is reported on failure as a secondary, scale-insensitive diagnostic.
+    np.testing.assert_allclose(
+        actual,
+        expected,
+        atol=ENCODE_ATOL,
+        rtol=0,
+        err_msg=f"{variant_name}: encode cos_sim={_cosine_sim(actual, expected):.6f}",
+    )
 
 
 def test_taef2_encode_shape_matches_8x_downsample() -> None:


### PR DESCRIPTION
## What this does

Tightens the library's central parity contract — "does the MLX port decode/encode the same as the PyTorch reference?" — from a cosine-similarity gate to an absolute-tolerance gate. Closes backlog item `mlx-taef-0001` (design-review finding H1, the only P1).

## Why

The end-to-end decode (`test_api.py`) and encode (`test_encoder.py`) parity tests gated only on `cosine_sim > 0.999`. On the `[0, 1]` images these decoders produce (reference mean ~0.43), cosine similarity is DC-dominated and nearly brightness/scale-invariant, so it accepts regressions orders of magnitude larger than the implementation actually produces:

- +0.05 brightness shift → cosine **0.9996** (passes the old gate)
- ×1.5 contrast → cosine 0.9994 (passes)
- per-pixel Gaussian noise std 0.02 → cosine 0.9990 (passes)

A wrong latent scale factor, dropped conv bias, off-by-one channel, or fp16 leaking into the fp32 path could produce a structurally-similar-but-wrong output that the gate would wave through.

## What was measured

Before setting tolerances, I measured the real MLX-Metal-fp32 vs PyTorch-fp32 diff on the committed fixtures (max-abs / max-rel / cosine per fixture):

| Path | Fixtures | Worst maxabs | Committed gate | Headroom |
|------|----------|--------------|----------------|----------|
| decode | 4 variants × 5 | ~1.1e-5 | `atol=1e-4, rtol=0` | ~9× |
| encode | 4 variants × 1 | ~2.4e-4 (taef1) | `atol=1e-3, rtol=0` | ~4× |

`rtol=0` is deliberate: pixel and latent values pass through zero, so relative tolerance is undefined near zero (measured `maxrel` explodes to ~3.0 at near-black pixels). Absolute tolerance is the correct tool here.

Note one deviation from the backlog's proposed values: the review suggested `atol=1e-4` for **encode** too, but measurement showed taef1's real diff is 2.4e-4 — `1e-4` would false-fail it. The encode path therefore carries its own looser tolerance (`1e-3`, the small-model full-forward fp32 value), an order looser than decode. Measuring first caught this.

## What changed for users

Nothing at runtime — this is test-only. The parity *contract* the library advertises is now meaningfully strict: a brightness/scale/bias regression that shifts pixels by ≥1e-4 (or latents by ≥1e-3) now fails CI instead of passing. Cosine similarity is retained only as a secondary diagnostic in the failure message, not as the pass/fail criterion.

## Test plan

- `test_variant_decode_against_committed_reference` and `test_variant_encode_parity` now gate on `np.testing.assert_allclose`.
- New `test_decode_parity_gate_rejects_brightness_shift` asserts the decode gate rejects a +0.05 shift *and* confirms the old cosine metric would have accepted it (a permanent guard against re-loosening).
- Full fast suite: **144 passed**, 15 slow/gpu deselected. `ruff check` + `ruff format --check` clean. `mypy` config only covers `src/`, untouched here.

## Risk surface

Low. Test-only; no `src/` change. The committed tolerances were measured on an M1 Max — if a CI runner on different Metal hardware produces fp32 reduction-order noise above the committed `atol`, a parity test could false-fail; the ~4–9× headroom above local worst-case is sized for that, but it is the one thing to watch on the first CI run on GitHub's macOS runners.