### PR TITLE
fix: fail loudly on incomplete HF->MLX conversion and weight load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `ConversionError` (exported from `mlx_taef`) and a convert-time coverage + shape
+  check in the HF→MLX weight converter. A conversion that fails to produce an
+  expected model parameter, or produces one whose shape disagrees with the model,
+  now raises and names the offending keys instead of silently writing an
+  incomplete or wrong weights file.
+
 ### Changed
+- `from_pretrained_local` now loads each submodule with `strict=True`. A weights
+  file that is missing a parameter, or carries a wrong-shaped one, raises at load
+  time instead of leaving the parameter at random init (a silently-wrong image).
+  Loading is done per submodule so decoder-only loading (no `encoder_path`) stays
+  valid — the encoder simply remains at init, as before.
 - End-to-end decode and encode parity tests now gate on an absolute pixel/latent
   tolerance (`np.testing.assert_allclose`) instead of cosine similarity > 0.999.
   On the `[0, 1]` images these decoders produce, cosine similarity is DC-dominated

--- a/src/mlx_taef/__init__.py
+++ b/src/mlx_taef/__init__.py
@@ -4,6 +4,7 @@ import logging
 
 from mlx_taef.api import TAEF1, TAEF2, TAESD, TAESDXL, Taef
 from mlx_taef.errors import (
+    ConversionError,
     FixtureLatentMissingError,
     MlxTeacacheNotInstalledError,
     SchemaVersionError,
@@ -16,6 +17,7 @@ __all__ = [
     "TAEF2",
     "TAESD",
     "TAESDXL",
+    "ConversionError",
     "FixtureLatentMissingError",
     "MlxTeacacheNotInstalledError",
     "SchemaVersionError",

--- a/src/mlx_taef/api.py
+++ b/src/mlx_taef/api.py
@@ -70,14 +70,17 @@ class Taef(nn.Module):  # type: ignore[misc,name-defined]
             A loaded `Taef` instance ready for `decode()`.
         """
         instance = cls()
+        # Load each submodule with strict=True so a dropped or wrong-shaped weight
+        # raises instead of leaving a parameter at random init (silently-wrong
+        # image). Loading per-submodule — rather than the whole instance — keeps
+        # decoder-only loading valid: the encoder simply stays at init when no
+        # encoder_path is given, instead of tripping a top-level strict check on
+        # the (legitimately absent) encoder parameters.
         d_weights = cast("dict[str, mx.array]", mx.load(str(decoder_path)))
-        weights_list: list[tuple[str, mx.array]] = [
-            (f"decoder.{k}", v) for k, v in d_weights.items()
-        ]
-        if encoder_path is not None and hasattr(instance, "encoder"):
+        instance.decoder.load_weights(list(d_weights.items()), strict=True)
+        if encoder_path is not None:
             e_weights = cast("dict[str, mx.array]", mx.load(str(encoder_path)))
-            weights_list.extend((f"encoder.{k}", v) for k, v in e_weights.items())
-        instance.load_weights(weights_list, strict=False)
+            instance.encoder.load_weights(list(e_weights.items()), strict=True)
         if dtype is not mx.float32:
             instance.set_dtype(dtype)
         instance.eval()

--- a/src/mlx_taef/convert.py
+++ b/src/mlx_taef/convert.py
@@ -13,6 +13,7 @@ import numpy as np
 from huggingface_hub import hf_hub_download
 from safetensors.numpy import load_file as safetensors_load_numpy
 
+from mlx_taef.errors import ConversionError
 from mlx_taef.model import make_decoder
 from mlx_taef.variants import TaesdVariantConfig
 
@@ -150,7 +151,44 @@ def _build_mlx_state_dict(
         ):
             arr = np.transpose(arr, (0, 2, 3, 1)).copy()
         converted[dst_key] = mx.array(arr)
+    _verify_conversion_coverage(converted, expected_shapes)
     return converted
+
+
+def _verify_conversion_coverage(
+    converted: dict[str, mx.array],
+    expected_shapes: dict[str, tuple[int, ...]],
+) -> None:
+    """Raise if the conversion dropped an expected param or produced a wrong shape.
+
+    Extra *source* keys are dropped silently by `_build_mlx_state_dict` (e.g.
+    Diffusers-only keys the MLX module doesn't have) — that is intentional. What
+    must never happen silently is the reverse: an expected model parameter that
+    no source key produced (it would load at random init) or a produced
+    parameter whose shape disagrees with the model (it would be accepted
+    verbatim). Both yield a usable-looking but numerically wrong model.
+
+    Args:
+        converted: the MLX-keyed dict produced by the conversion loop.
+        expected_shapes: dotted-key -> shape for every model parameter.
+
+    Raises:
+        ConversionError: if any expected key is missing or any shape mismatches.
+    """
+    missing = sorted(set(expected_shapes) - set(converted))
+    mismatched = sorted(
+        f"{k}: got {tuple(converted[k].shape)}, expected {expected_shapes[k]}"
+        for k in converted
+        if tuple(converted[k].shape) != expected_shapes[k]
+    )
+    if not missing and not mismatched:
+        return
+    parts: list[str] = []
+    if missing:
+        parts.append(f"missing {len(missing)} expected parameter(s): {missing}")
+    if mismatched:
+        parts.append(f"shape mismatch on {len(mismatched)} parameter(s): {mismatched}")
+    raise ConversionError("HF->MLX conversion is incomplete — " + "; ".join(parts))
 
 
 def _flatten_module_param_shapes(module: Any, prefix: str = "") -> dict[str, tuple[int, ...]]:

--- a/src/mlx_taef/errors.py
+++ b/src/mlx_taef/errors.py
@@ -3,6 +3,7 @@
 Hierarchy:
     TaefError                              base for all package-rooted errors
     ├── SchemaVersionError                 unknown JSON schema_version
+    ├── ConversionError                    HF->MLX conversion dropped/mis-shaped a param
     ├── MlxTeacacheNotInstalledError       (+ ImportError) optional dep missing
     └── FixtureLatentMissingError          (+ FileNotFoundError) showcase fixture absent
 """
@@ -19,6 +20,16 @@ class SchemaVersionError(TaefError):
 
     Future schema bumps add adapters; raising rather than silently
     misinterpreting fields keeps the diff workflow honest.
+    """
+
+
+class ConversionError(TaefError):
+    """Raised when HF->MLX conversion fails to reproduce the model's parameters.
+
+    Covers two silent-failure paths: an expected parameter that no source key
+    produced (would load at random init) and a produced parameter whose shape
+    disagrees with the model (would be accepted verbatim). Both yield a
+    usable-looking but numerically wrong model, so conversion raises instead.
     """
 
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,11 +1,13 @@
 """Tests for HF -> MLX weight conversion."""
 
+import re
 from pathlib import Path
 
 import mlx.core as mx
 import numpy as np
 import pytest
 
+from mlx_taef import TAEF2
 from mlx_taef.convert import (
     _build_mlx_state_dict,
     _flatten_module_param_shapes,
@@ -14,6 +16,7 @@ from mlx_taef.convert import (
     convert_hf_decoder_to_mlx,
     convert_hf_encoder_to_mlx,
 )
+from mlx_taef.errors import ConversionError
 from mlx_taef.model import make_decoder, make_encoder
 from mlx_taef.variants import ALL_VARIANTS, TAEF2_CONFIG
 
@@ -76,10 +79,46 @@ def test_build_mlx_state_dict_transposes_4d_conv_weights() -> None:
     assert tuple(out["layers.1.weight"].shape) == (2, 3, 3, 3)
 
 
-def test_build_mlx_state_dict_skips_unmapped_keys() -> None:
-    sd = {"some.extra.key": np.zeros((2, 2))}
+def test_build_mlx_state_dict_drops_extra_source_keys() -> None:
+    """Extra source keys (e.g. Diffusers-only) are dropped as long as every
+    expected param is still produced — dropping unused keys is not an error."""
+    sd = {
+        "0.weight": np.zeros((2, 2), dtype=np.float32),  # -> layers.0.weight (expected)
+        "some.extra.key": np.zeros((2, 2), dtype=np.float32),  # unmapped, dropped
+    }
     out = _build_mlx_state_dict(sd, expected_shapes={"layers.0.weight": (2, 2)})
-    assert out == {}
+    assert set(out) == {"layers.0.weight"}
+
+
+def test_build_mlx_state_dict_raises_on_missing_expected_key() -> None:
+    """A source dict that fails to produce an expected param raises at convert
+    time, naming the missing key — instead of silently dropping it."""
+    sd = {"0.weight": np.zeros((2, 2), dtype=np.float32)}  # -> layers.0.weight
+    expected = {"layers.0.weight": (2, 2), "layers.1.bias": (4,)}  # layers.1.bias absent
+    with pytest.raises(ConversionError, match=re.escape("layers.1.bias")):
+        _build_mlx_state_dict(sd, expected_shapes=expected)
+
+
+def test_build_mlx_state_dict_raises_on_wrong_shape() -> None:
+    """A produced param whose shape disagrees with the model raises at convert
+    time, naming the key and both shapes — instead of accepting it verbatim."""
+    sd = {"0.weight": np.zeros((5, 5), dtype=np.float32)}  # -> layers.0.weight, wrong shape
+    expected = {"layers.0.weight": (2, 2)}
+    with pytest.raises(ConversionError, match=re.escape("layers.0.weight")):
+        _build_mlx_state_dict(sd, expected_shapes=expected)
+
+
+def test_from_pretrained_local_raises_on_incomplete_decoder(tmp_path: Path) -> None:
+    """from_pretrained_local loads with strict=True: a decoder file missing a
+    parameter must raise rather than leave it at random init (silently wrong)."""
+    full = mx.load(str(Path(__file__).parent / "converted" / "taef2_decoder.safetensors"))
+    dropped_key = next(k for k in full if k.endswith(".weight"))
+    incomplete = {k: v for k, v in full.items() if k != dropped_key}
+    incomplete_path = tmp_path / "incomplete_decoder.safetensors"
+    mx.save_safetensors(str(incomplete_path), dict(incomplete))
+    # MLX load_weights(strict=True) raises ValueError("Missing N parameters: ...").
+    with pytest.raises(ValueError, match="Missing"):
+        TAEF2.from_pretrained_local(incomplete_path)
 
 
 def test_flatten_module_param_shapes_walks_nested_sequentials() -> None:


### PR DESCRIPTION
## What this does

Closes backlog item `mlx-taef-0002` (design-review finding M1). Removes two compounding silent-failure paths that let a bad weight conversion produce a usable-looking but numerically wrong model instead of raising. Pairs with the parity-gate work in #7 — together they are the "silently-wrong model" defense.

## The two paths

1. **Convert side** — `_build_mlx_state_dict` skipped any source key whose remapped name wasn't in `expected_shapes` (`continue`, no warning), with no reciprocal check that every *expected* parameter was produced, and no shape check on the ones it did produce. A remapping bug or a new variant could drop a weight or keep a wrong-shaped one, and the converter would happily write the file.
2. **Load side** — `from_pretrained_local` used `load_weights(..., strict=False)`. A missing weight left a parameter at random init; a wrong-shaped weight was accepted verbatim. Both yield silently-wrong images.

Committed weights are validated today, so this was a latent footgun for future variants / a conversion regression, not an active bug.

## The fix

- New package-rooted `ConversionError(TaefError)`, exported from `mlx_taef`.
- `_build_mlx_state_dict` now runs `_verify_conversion_coverage`: it raises `ConversionError` naming any **missing** expected params and any **shape mismatches**. Extra *source* keys are still dropped silently — that's intentional (Diffusers files carry keys the MLX module doesn't have).
- `from_pretrained_local` switches to `strict=True`.

### Design note (deviation from the item as written)

The item said "`from_pretrained_local` uses `strict=True`". A naive *top-level* `strict=True` would **break decoder-only loading**: the instance always constructs `self.encoder`, but decoder-only callers (most of `test_api.py`, and `from_pretrained(..., include_encoder=False)`) pass no encoder weights, so a top-level strict check would fail on the legitimately-absent encoder params. The fix loads **per submodule** — `instance.decoder.load_weights(..., strict=True)` and, when an `encoder_path` is given, `instance.encoder.load_weights(..., strict=True)`. Each side is strictly validated against exactly its own weights, and decoder-only loading stays valid (encoder remains at init, as before).

## Built with TDD

RED → GREEN → REFACTOR. The tests were written first and watched fail (ImportError on `ConversionError`, then "DID NOT RAISE") before any production code.

## Test plan

Non-network unit tests (run in CI's fast path):
- `_build_mlx_state_dict` raises `ConversionError` on a **missing** expected key (names it).
- `_build_mlx_state_dict` raises `ConversionError` on a **wrong-shaped** key (names key + both shapes).
- `from_pretrained_local` on an incomplete decoder file raises `ValueError("Missing N parameters: ...")` — proving `strict=True` is live.
- Reworked the old `test_build_mlx_state_dict_skips_unmapped_keys` (which encoded the silent-skip bug) into `test_build_mlx_state_dict_drops_extra_source_keys`, preserving its real intent (extra source keys are dropped) while satisfying coverage.

Full fast suite: **147 passed** (was 144; +3), 15 slow/network deselected. `ruff check` + `ruff format --check` clean. `mypy` clean (12 source files).

## Risk surface

Low, but one behavior change existing users will notice: a corrupted, truncated, or version-mismatched local weights file that previously loaded into a wrong-but-runnable model now raises at `from_pretrained_local`. That is the intended improvement. The network-marked end-to-end conversion tests now also exercise the coverage check; real complete conversions produce the full keyset, so they pass unchanged.