### PR TITLE
chore: skip network/benchmark tests by default; drop dead markers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,4 +57,4 @@ jobs:
             --cov=mlx_taef \
             --cov-report=term-missing \
             --cov-fail-under=95 \
-            -m "not benchmark and not network and not slow and not integration"
+            -m "not benchmark and not network"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   maxabs ~1.1e-5) and `atol=1e-3` for encode (measured worst ~2.4e-4 on taef1);
   both use `rtol=0` because the values pass through zero. A regression test now
   asserts the decode gate rejects a +0.05 shift.
+- A bare `pytest` (or `uv run pytest`) now skips the `network` and `benchmark`
+  tests by default, so a local run is fast and offline and matches what CI runs.
+  Opt back in with `--run-network` (real HF downloads) or `--run-benchmark` (perf
+  timings). Previously the only deselection lived in the CI invocation, so a bare
+  local run attempted the real downloads and the benchmark timings.
+
+### Removed
+- Unused `slow`, `gpu`, and `integration` pytest markers, which were registered
+  but applied to zero tests. `network` and `benchmark` remain.
 
 ## [0.2.2] — 2026-05-27
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,11 +179,8 @@ addopts = "-ra --strict-markers --strict-config"
 testpaths = ["tests"]
 xfail_strict = true
 markers = [
-  "slow: tests >1s",
-  "gpu: requires Metal GPU",
-  "network: requires network access (skipped in CI)",
-  "benchmark: perf test (skipped in CI)",
-  "integration: needs real model checkpoint",
+  "network: real network I/O (HF downloads); skipped by default, opt in with --run-network",
+  "benchmark: perf timing test; skipped by default, opt in with --run-benchmark",
 ]
 
 [tool.coverage.run]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,58 @@ def _install_mlx_memory_caps() -> tuple[int, int]:
 INSTALLED_CAPS_GB = _install_mlx_memory_caps()
 
 
+# Collection gating: keep a bare `pytest` fast and offline. Tests carrying these
+# markers do real I/O (network) or minutes of perf measurement (benchmark), so a
+# developer running `uv run pytest` with no flags should not pay for them — they
+# are skipped unless the matching opt-in flag is passed. Each tuple is
+# (marker, opt-in flag, short description).
+GATED_MARKERS: tuple[tuple[str, str, str], ...] = (
+    ("network", "--run-network", "real HF downloads"),
+    ("benchmark", "--run-benchmark", "perf timings, slow and noisy"),
+)
+
+
+def _markers_to_skip(enabled_flags: set[str]) -> list[tuple[str, str]]:
+    """Pure decision: which (marker, skip-reason) pairs to skip given opt-in flags.
+
+    Separated from the pytest hook so the gating policy is unit-testable without
+    a live pytest session.
+
+    Args:
+        enabled_flags: the opt-in flags present on this invocation (e.g.
+            ``{"--run-network"}``).
+
+    Returns:
+        ``(marker, reason)`` pairs whose tests should be skipped this run.
+    """
+    return [
+        (marker, f"requires {flag} ({desc})")
+        for marker, flag, desc in GATED_MARKERS
+        if flag not in enabled_flags
+    ]
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Register the opt-in flags for the gated markers."""
+    for marker, flag, desc in GATED_MARKERS:
+        parser.addoption(
+            flag,
+            action="store_true",
+            default=False,
+            help=f"run `{marker}`-marked tests ({desc}); skipped by default",
+        )
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Skip gated tests unless their opt-in flag was passed, so a bare run is fast+offline."""
+    enabled = {flag for _marker, flag, _desc in GATED_MARKERS if config.getoption(flag)}
+    for marker, reason in _markers_to_skip(enabled):
+        skip = pytest.mark.skip(reason=reason)
+        for item in items:
+            if marker in item.keywords:
+                item.add_marker(skip)
+
+
 CONVERTED_DIR = Path(__file__).parent / "converted"
 REF_DIR = Path(__file__).parent / "reference"
 

--- a/tests/test_collection_gating.py
+++ b/tests/test_collection_gating.py
@@ -1,0 +1,31 @@
+"""Tests for the conftest collection-gating logic (network/benchmark opt-in).
+
+These cover the pure decision (`_markers_to_skip`) directly; the pytest wiring
+(`pytest_addoption` / `pytest_collection_modifyitems`) is exercised behaviorally
+by running the suite with and without the opt-in flags.
+"""
+
+from tests.conftest import _markers_to_skip
+
+
+def test_no_flags_skips_network_and_benchmark() -> None:
+    """A bare run (no opt-in flags present) skips both gated markers."""
+    skipped = {marker for marker, _reason in _markers_to_skip(set())}
+    assert skipped == {"network", "benchmark"}
+
+
+def test_run_network_opts_in_network_only() -> None:
+    """--run-network un-skips network but leaves benchmark skipped."""
+    skipped = {marker for marker, _reason in _markers_to_skip({"--run-network"})}
+    assert skipped == {"benchmark"}
+
+
+def test_run_benchmark_opts_in_benchmark_only() -> None:
+    """--run-benchmark un-skips benchmark but leaves network skipped."""
+    skipped = {marker for marker, _reason in _markers_to_skip({"--run-benchmark"})}
+    assert skipped == {"network"}
+
+
+def test_all_flags_skip_nothing() -> None:
+    """With both opt-in flags present, nothing is gated."""
+    assert _markers_to_skip({"--run-network", "--run-benchmark"}) == []


### PR DESCRIPTION
## What this does

Closes backlog item `mlx-taef-0003` (design-review M2). Makes a bare `uv run pytest` fast and offline by default, so a local run matches CI without anyone having to remember the `-m` exclusion string.

## Why

Deselection of `network` / `benchmark` tests lived only in the CI invocation's `-m` string. A developer running a bare `uv run pytest` locally attempted the real HF-download tests (fail or hang offline) and ran the benchmark perf tests (minutes of noise). Separately, three registered markers — `slow`, `gpu`, `integration` — were applied to zero tests, i.e. dead configuration.

## The fix

- A `conftest.py` collection hook (`pytest_addoption` + `pytest_collection_modifyitems`) skips `network` and `benchmark` by default. Opt back in with `--run-network` (real HF downloads) or `--run-benchmark` (perf timings).
- The skip *decision* is factored into a pure helper, `_markers_to_skip(enabled_flags)`, so the gating policy is unit-tested directly without a live pytest session.
- Removed the unused `slow`, `gpu`, `integration` markers; `network` and `benchmark` remain (they're applied).
- Simplified the CI `-m` to `"not benchmark and not network"` (it referenced the now-removed markers).

## Built with TDD

The gating policy was test-first: `tests/test_collection_gating.py` was written and watched fail (`ImportError: cannot import name '_markers_to_skip'`) before the helper existed, then implemented to green. The pytest *wiring* (addoption / modifyitems) is verified behaviorally rather than unit-tested, since that's pytest's own plumbing.

## Test plan

- **Unit (the decision):** `_markers_to_skip` with no flags returns both gated markers; with `--run-network` returns only `benchmark`; with `--run-benchmark` returns only `network`; with both returns nothing. 4 tests.
- **Behavioral (the wiring):**
  - Bare `pytest -rs`: **151 passed, 15 skipped** — all `network` (13, incl. a parametrized 8) and `benchmark` (2) skipped with reasons, zero network I/O.
  - `pytest --run-benchmark -m benchmark`: 2 benchmark tests run live (no network) — proves the opt-in flag un-gates its marker through the real hook.
  - `pytest --run-network -m network --collect-only`: the flag is accepted and re-selects all 13 network tests.
- CI-equivalent run (`-m "not benchmark and not network" --cov-fail-under=95`): 151 passed, coverage **97.6%**. `ruff` + `mypy` clean.

## Risk surface

Low, dev-only. No `src/` change, no runtime behavior change for library users. The one behavior change is local: a bare `pytest` now skips the network/benchmark tests instead of attempting them. CI runs the same effective set as before.