### PR TITLE
docs: release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.3] — 2026-05-29
 
 ### Added
 - `ConversionError` (exported from `mlx_taef`) and a convert-time coverage + shape

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ See `docs/manual-verification.md` for the full verification recipe.
 
 - **v0.1.0 — initial public release on PyPI** (2026-05-13). All four variants, encoder + decoder, mflux integration, CI, 99 % honest coverage.
 - **v0.2.0 — released on PyPI** (2026-05-27). Auto-bn extraction in `LivePreviewCallback(flux=...)`; per-step gallery mode (`numbered_frames=True`); subprocess-per-rep showcase bench (`scripts/run_showcase.py`); hardware-aware memory caps via `mlx_taef._memory_caps`; [COMPARISON.md](COMPARISON.md) + committed JSON report; [ROADMAP.md](ROADMAP.md).
+- **v0.2.3 — released on PyPI** (2026-05-29). Weight loading is now strict: `from_pretrained_local` raises on an incomplete or wrong-shaped weights file instead of loading a silently-wrong model, and the HF→MLX converter checks parameter coverage and shapes at convert time (new `ConversionError`). The end-to-end parity tests now gate on an absolute pixel tolerance rather than cosine similarity. A bare `pytest` skips the network and benchmark tests by default (`--run-network` / `--run-benchmark` to opt in).
 
 Track future releases via the [PyPI history](https://pypi.org/project/mlx-taef/#history) or `gh release list -R IonDen/mlx-taef`.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,6 +4,7 @@ A non-binding sketch of where the library is headed. Each item lists status, eff
 
 ## Released
 
+- **v0.2.3** (2026-05-29) — strict weight loading: `from_pretrained_local` raises on an incomplete or wrong-shaped weights file instead of loading a silently-wrong model (new `ConversionError`); the HF→MLX converter validates parameter coverage and shapes at convert time; end-to-end parity tests gate on an absolute pixel/latent tolerance instead of cosine similarity; a bare `pytest` skips network and benchmark tests by default, with `--run-network` / `--run-benchmark` opt-ins.
 - **v0.2.0** (2026-05-27) — `LivePreviewCallback` auto-bn extraction for taef2; [COMPARISON.md](COMPARISON.md) + `scripts/run_showcase.py` measured showcase (4 scenarios); subprocess-per-rep `scripts/bench_decode.py`; per-variant `memory_cap_hint_gb` + `FULL_VAE_CAP_GB`; session-level `tests/conftest.py` MLX cap; cross-process MLX non-determinism caveat in [docs/manual-verification.md](docs/manual-verification.md); Trove classifier alignment; `showcase` runtime extra.
 - **v0.1.1** (2026-05-13) — sha256 sidecars on committed fixtures; SSIM ≥ 0.75 perceptual contract on roundtrip; release workflow ships a GitHub Release on tag push.
 - **v0.1.0** (2026-05-13) — initial public release. 4 variants (TAESD, TAESDXL, TAEF1, TAEF2) with one consistent API. mflux `LivePreviewCallback`. 99-100% coverage.


### PR DESCRIPTION
## Release v0.2.3

Release-prep PR — docs only. Finalizes the CHANGELOG `[Unreleased]` section as `[0.2.3]` (2026-05-29) and adds the v0.2.3 line to the README **Status** list and the ROADMAP **Released** section. No code changes (the three fixes below already merged to `main`).

Version is tag-driven via hatch-vcs (`dynamic = ["version"]`), so there is no version string to bump — **tagging `v0.2.3` after this merges triggers the PyPI Trusted-Publishing workflow** (`release.yml` on `push: tags: ["v*"]`).

## What v0.2.3 ships

Three design-review findings, already on `main`:

- **Strict weight loading + conversion validation** (PR #8, `mlx-taef-0002`). `from_pretrained_local` now loads each submodule with `strict=True`, and the HF→MLX converter checks parameter coverage + shapes at convert time, raising a new public `ConversionError`. A missing or wrong-shaped weight now raises instead of producing a silently-wrong model. **This is the one user-visible runtime change**: a corrupt/incomplete local weights file that used to load now raises.
- **Absolute-tolerance parity gate** (PR #7, `mlx-taef-0001`). End-to-end decode/encode parity tests gate on `assert_allclose` (`atol=1e-4` decode, `1e-3` encode) instead of cosine similarity > 0.999, which was brightness/scale-blind. Test-only.
- **Fast + offline local pytest** (PR #9, `mlx-taef-0003`). A bare `pytest` skips `network` and `benchmark` tests by default; opt in with `--run-network` / `--run-benchmark`. Dev-only.

## After merge

I tag `v0.2.3` on `main` and push — with your explicit go-ahead at that step — which publishes to PyPI and creates the GitHub Release.