### PR TITLE
release: v0.2.4 — internal test + showcase-gate hardening (0032, 0033, 0038)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.4] — 2026-06-03
+
+Internal hardening only. No change to the library API, runtime behavior, or the
+published wheel; every change is in the test suite and developer tooling
+(`scripts/`), neither of which ships in the package.
+
+### Changed
+- The showcase regression gate (`scripts/diff_showcase_report.py`) now also guards
+  the headline peak-memory metric and the TeaCache `skipped_count`, and flags a
+  baseline metric or block disappearing from a new report rather than only a worse
+  number (new `--memory-tolerance`, default 0.10). Previously a memory regression or
+  a dropped skip count passed the gate silently.
+
+### Tests
+- The error tests drive real bad inputs through each package error's raise site
+  (`ConversionError`, `SchemaVersionError`, `FixtureLatentMissingError`) instead of
+  only asserting the class hierarchy, and the bench harness's `_resolve_cap_gb`
+  unknown-condition guard gained the raise test it was missing. Each new
+  raise-condition test was mutation-verified.
+
 ## [0.2.3] — 2026-05-29
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,6 +4,7 @@ A non-binding sketch of where the library is headed. Each item lists status, eff
 
 ## Released
 
+- **v0.2.4** (2026-06-03) — internal hardening, no user-facing change: the showcase regression gate now guards peak-memory and the TeaCache `skipped_count` (and a dropped metric/block), and the error/bench tests now exercise real raise conditions instead of just class declarations. Test suite and `scripts/` only; the published wheel is unchanged.
 - **v0.2.3** (2026-05-29) — strict weight loading: `from_pretrained_local` raises on an incomplete or wrong-shaped weights file instead of loading a silently-wrong model (new `ConversionError`); the HF→MLX converter validates parameter coverage and shapes at convert time; end-to-end parity tests gate on an absolute pixel/latent tolerance instead of cosine similarity; a bare `pytest` skips network and benchmark tests by default, with `--run-network` / `--run-benchmark` opt-ins.
 - **v0.2.0** (2026-05-27) — `LivePreviewCallback` auto-bn extraction for taef2; [COMPARISON.md](COMPARISON.md) + `scripts/run_showcase.py` measured showcase (4 scenarios); subprocess-per-rep `scripts/bench_decode.py`; per-variant `memory_cap_hint_gb` + `FULL_VAE_CAP_GB`; session-level `tests/conftest.py` MLX cap; cross-process MLX non-determinism caveat in [docs/manual-verification.md](docs/manual-verification.md); Trove classifier alignment; `showcase` runtime extra.
 - **v0.1.1** (2026-05-13) — sha256 sidecars on committed fixtures; SSIM ≥ 0.75 perceptual contract on roundtrip; release workflow ships a GitHub Release on tag push.

--- a/scripts/diff_showcase_report.py
+++ b/scripts/diff_showcase_report.py
@@ -34,13 +34,23 @@ def diff_reports(
     *,
     wallclock_tolerance: float = 0.10,
     ssim_tolerance: float = 0.05,
+    memory_tolerance: float = 0.10,
 ) -> list[dict[str, Any]]:
     """Return a list of regression records; empty list means no regression.
 
     Checks (per scenario):
-      - For `taef*_vs_vae`: each known condition's `median_seconds`, plus
-        scenario-level `ssim_median`.
-      - For `live_preview` / `combined`: scenario-level `elapsed_s`.
+      - For `taef*_vs_vae`: each known condition's `median_seconds` and
+        `median_peak_memory_gb`, plus scenario-level `ssim_median`.
+      - For `live_preview` / `combined`: scenario-level `elapsed_s` and
+        `peak_memory_gb`.
+      - For any scenario carrying `teacache.skipped_count` (the `combined`
+        scenario): a floor — a drop below the baseline count is flagged, so a
+        TeaCache integration regression that stops skipping steps cannot pass
+        silently.
+
+    Peak memory is the library's headline win (a few-MB decoder vs the full
+    VAE), so a memory regression is gated with the same drift shape as
+    wall-clock.
     """
     regressions: list[dict[str, Any]] = []
     old_scenarios = old.get("scenarios", {})
@@ -49,7 +59,7 @@ def diff_reports(
     for scenario, new_data in new_scenarios.items():
         old_data = old_scenarios.get(scenario, {})
 
-        # taef*_vs_vae conditions → median_seconds per condition
+        # taef*_vs_vae conditions → median_seconds + median_peak_memory_gb per condition
         for cond in _VS_VAE_CONDITION_KEYS:
             new_cond = new_data.get(cond)
             old_cond = old_data.get(cond)
@@ -57,20 +67,42 @@ def diff_reports(
                 continue
             old_med = old_cond.get("median_seconds")
             new_med = new_cond.get("median_seconds")
-            if old_med is None or new_med is None or old_med <= 0:
-                continue
-            drift = (new_med - old_med) / old_med
-            if drift > wallclock_tolerance:
-                regressions.append(
-                    {
-                        "kind": "wallclock-drift",
-                        "scenario": scenario,
-                        "condition": cond,
-                        "old_seconds": old_med,
-                        "new_seconds": new_med,
-                        "drift_pct": drift * 100,
-                    }
-                )
+            if (
+                isinstance(old_med, (int, float))
+                and isinstance(new_med, (int, float))
+                and old_med > 0
+            ):
+                drift = (new_med - old_med) / old_med
+                if drift > wallclock_tolerance:
+                    regressions.append(
+                        {
+                            "kind": "wallclock-drift",
+                            "scenario": scenario,
+                            "condition": cond,
+                            "old_seconds": old_med,
+                            "new_seconds": new_med,
+                            "drift_pct": drift * 100,
+                        }
+                    )
+            old_mem = old_cond.get("median_peak_memory_gb")
+            new_mem = new_cond.get("median_peak_memory_gb")
+            if (
+                isinstance(old_mem, (int, float))
+                and isinstance(new_mem, (int, float))
+                and old_mem > 0
+            ):
+                mem_drift = (new_mem - old_mem) / old_mem
+                if mem_drift > memory_tolerance:
+                    regressions.append(
+                        {
+                            "kind": "peak-memory-drift",
+                            "scenario": scenario,
+                            "condition": cond,
+                            "old_gb": old_mem,
+                            "new_gb": new_mem,
+                            "drift_pct": mem_drift * 100,
+                        }
+                    )
 
         # Live scenarios → scenario-level elapsed_s
         old_elapsed = old_data.get("elapsed_s")
@@ -92,6 +124,45 @@ def diff_reports(
                         "drift_pct": drift * 100,
                     }
                 )
+
+        # Scenario-level peak_memory_gb (live_preview / combined)
+        old_peak = old_data.get("peak_memory_gb")
+        new_peak = new_data.get("peak_memory_gb")
+        if (
+            isinstance(old_peak, (int, float))
+            and isinstance(new_peak, (int, float))
+            and old_peak > 0
+        ):
+            mem_drift = (new_peak - old_peak) / old_peak
+            if mem_drift > memory_tolerance:
+                regressions.append(
+                    {
+                        "kind": "peak-memory-drift",
+                        "scenario": scenario,
+                        "condition": "(scenario)",
+                        "old_gb": old_peak,
+                        "new_gb": new_peak,
+                        "drift_pct": mem_drift * 100,
+                    }
+                )
+
+        # TeaCache skipped_count floor: a drop below the baseline count means
+        # the integration stopped skipping steps (the combined scenario).
+        old_skipped = (old_data.get("teacache") or {}).get("skipped_count")
+        new_skipped = (new_data.get("teacache") or {}).get("skipped_count")
+        if (
+            isinstance(old_skipped, int)
+            and isinstance(new_skipped, int)
+            and new_skipped < old_skipped
+        ):
+            regressions.append(
+                {
+                    "kind": "skipped-count-drop",
+                    "scenario": scenario,
+                    "old_skipped": old_skipped,
+                    "new_skipped": new_skipped,
+                }
+            )
 
         # SSIM at scenario level (taef*_vs_vae only — live scenarios have no SSIM)
         old_ssim = old_data.get("ssim_median")
@@ -121,6 +192,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("new", type=Path)
     parser.add_argument("--wallclock-tolerance", type=float, default=0.10)
     parser.add_argument("--ssim-tolerance", type=float, default=0.05)
+    parser.add_argument("--memory-tolerance", type=float, default=0.10)
     args = parser.parse_args(argv)
 
     old = json.loads(args.old.read_text())
@@ -131,6 +203,7 @@ def main(argv: list[str] | None = None) -> int:
         new,
         wallclock_tolerance=args.wallclock_tolerance,
         ssim_tolerance=args.ssim_tolerance,
+        memory_tolerance=args.memory_tolerance,
     )
     if not regressions:
         print("No regressions detected.")

--- a/scripts/diff_showcase_report.py
+++ b/scripts/diff_showcase_report.py
@@ -1,12 +1,17 @@
 r"""Machine-enforced regression checker for two showcase reports.
 
-Exits non-zero if any wall-clock metric drifts more than the tolerance
-or any SSIM drops more than the tolerance. Schema follows the actual
-output of `scripts/run_showcase.py` (NOT the early-spec sketch):
+Exits non-zero if any wall-clock or peak-memory metric drifts more than the
+tolerance, any SSIM drops more than the tolerance, the TeaCache skip count
+drops, or a baseline metric/block disappears from the new report. Schema
+follows the actual output of `scripts/run_showcase.py` (NOT the early-spec
+sketch):
 
-    scenarios.<name>.{taef,vanilla_vae}.median_seconds  # taef*_vs_vae
-    scenarios.<name>.ssim_median                        # taef*_vs_vae
-    scenarios.<name>.elapsed_s                          # live_preview, combined
+    scenarios.<name>.{taef,vanilla_vae}.median_seconds         # taef*_vs_vae
+    scenarios.<name>.{taef,vanilla_vae}.median_peak_memory_gb  # taef*_vs_vae
+    scenarios.<name>.ssim_median                               # taef*_vs_vae
+    scenarios.<name>.elapsed_s                                 # live_preview, combined
+    scenarios.<name>.peak_memory_gb                            # live_preview, combined
+    scenarios.combined.teacache.skipped_count                  # combined
 
 Usage:
     uv run python scripts/run_showcase.py --report new.json
@@ -86,23 +91,30 @@ def diff_reports(
                     )
             old_mem = old_cond.get("median_peak_memory_gb")
             new_mem = new_cond.get("median_peak_memory_gb")
-            if (
-                isinstance(old_mem, (int, float))
-                and isinstance(new_mem, (int, float))
-                and old_mem > 0
-            ):
-                mem_drift = (new_mem - old_mem) / old_mem
-                if mem_drift > memory_tolerance:
+            if isinstance(old_mem, (int, float)) and old_mem > 0:
+                if not isinstance(new_mem, (int, float)):
                     regressions.append(
                         {
-                            "kind": "peak-memory-drift",
+                            "kind": "peak-memory-missing",
                             "scenario": scenario,
                             "condition": cond,
                             "old_gb": old_mem,
                             "new_gb": new_mem,
-                            "drift_pct": mem_drift * 100,
                         }
                     )
+                else:
+                    mem_drift = (new_mem - old_mem) / old_mem
+                    if mem_drift > memory_tolerance:
+                        regressions.append(
+                            {
+                                "kind": "peak-memory-drift",
+                                "scenario": scenario,
+                                "condition": cond,
+                                "old_gb": old_mem,
+                                "new_gb": new_mem,
+                                "drift_pct": mem_drift * 100,
+                            }
+                        )
 
         # Live scenarios → scenario-level elapsed_s
         old_elapsed = old_data.get("elapsed_s")
@@ -128,41 +140,56 @@ def diff_reports(
         # Scenario-level peak_memory_gb (live_preview / combined)
         old_peak = old_data.get("peak_memory_gb")
         new_peak = new_data.get("peak_memory_gb")
-        if (
-            isinstance(old_peak, (int, float))
-            and isinstance(new_peak, (int, float))
-            and old_peak > 0
-        ):
-            mem_drift = (new_peak - old_peak) / old_peak
-            if mem_drift > memory_tolerance:
+        if isinstance(old_peak, (int, float)) and old_peak > 0:
+            if not isinstance(new_peak, (int, float)):
                 regressions.append(
                     {
-                        "kind": "peak-memory-drift",
+                        "kind": "peak-memory-missing",
                         "scenario": scenario,
                         "condition": "(scenario)",
                         "old_gb": old_peak,
                         "new_gb": new_peak,
-                        "drift_pct": mem_drift * 100,
                     }
                 )
+            else:
+                mem_drift = (new_peak - old_peak) / old_peak
+                if mem_drift > memory_tolerance:
+                    regressions.append(
+                        {
+                            "kind": "peak-memory-drift",
+                            "scenario": scenario,
+                            "condition": "(scenario)",
+                            "old_gb": old_peak,
+                            "new_gb": new_peak,
+                            "drift_pct": mem_drift * 100,
+                        }
+                    )
 
         # TeaCache skipped_count floor: a drop below the baseline count means
         # the integration stopped skipping steps (the combined scenario).
         old_skipped = (old_data.get("teacache") or {}).get("skipped_count")
         new_skipped = (new_data.get("teacache") or {}).get("skipped_count")
-        if (
-            isinstance(old_skipped, int)
-            and isinstance(new_skipped, int)
-            and new_skipped < old_skipped
-        ):
-            regressions.append(
-                {
-                    "kind": "skipped-count-drop",
-                    "scenario": scenario,
-                    "old_skipped": old_skipped,
-                    "new_skipped": new_skipped,
-                }
-            )
+        if isinstance(old_skipped, int) and not isinstance(old_skipped, bool):
+            if not isinstance(new_skipped, int) or isinstance(new_skipped, bool):
+                # The teacache block / skipped_count field disappeared (the
+                # TeaCache wiring removed outright) — worse than a 1 -> 0 drop.
+                regressions.append(
+                    {
+                        "kind": "skipped-count-missing",
+                        "scenario": scenario,
+                        "old_skipped": old_skipped,
+                        "new_skipped": new_skipped,
+                    }
+                )
+            elif new_skipped < old_skipped:
+                regressions.append(
+                    {
+                        "kind": "skipped-count-drop",
+                        "scenario": scenario,
+                        "old_skipped": old_skipped,
+                        "new_skipped": new_skipped,
+                    }
+                )
 
         # SSIM at scenario level (taef*_vs_vae only — live scenarios have no SSIM)
         old_ssim = old_data.get("ssim_median")

--- a/tests/test_bench_decode.py
+++ b/tests/test_bench_decode.py
@@ -144,6 +144,17 @@ def test_orchestrator_dispatch_per_condition_cap_split() -> None:
     assert _resolve_cap_gb(condition="vanilla_vae", flux_variant="flux2-klein-base-4b") == 12
 
 
+def test_resolve_cap_gb_raises_on_unknown_condition() -> None:
+    """The success paths are covered above; the unknown-condition guard at the
+    bottom of _resolve_cap_gb must raise TaefError, not fall through / return None."""
+    from scripts.bench_decode import _resolve_cap_gb
+
+    from mlx_taef.errors import TaefError
+
+    with pytest.raises(TaefError, match="unknown condition"):
+        _resolve_cap_gb(condition="totally-bogus")
+
+
 def test_orchestrator_records_failed_rep_and_continues() -> None:
     """When a worker subprocess fails, the rep is recorded with the
     error and the orchestrator moves on."""

--- a/tests/test_diff_showcase_report.py
+++ b/tests/test_diff_showcase_report.py
@@ -295,3 +295,52 @@ def test_self_diff_with_zeroed_skipped_count_finds_regression() -> None:
     regressions = diff_reports(old, new)
     flagged = [r for r in regressions if r["kind"] == "skipped-count-drop"]
     assert flagged, f"expected a skipped-count-drop, got {regressions}"
+
+
+# --- the metric/block disappearing entirely is the worst regression and must
+#     also be flagged (not just a worse number) ---
+
+
+def test_skipped_count_block_removed_flagged() -> None:
+    """Losing the whole teacache block (the TeaCache wiring removed outright) is
+    a worse regression than 1 -> 0, and must not pass silently."""
+    from scripts.diff_showcase_report import diff_reports
+
+    old = _make_combined_report(skipped_count=1)
+    new = _make_combined_report(skipped_count=1)
+    del new["scenarios"]["combined"]["teacache"]
+
+    regressions = diff_reports(old, new)
+    flagged = [r for r in regressions if r["kind"] == "skipped-count-missing"]
+    assert len(flagged) == 1, f"expected a skipped-count-missing, got {regressions}"
+    assert flagged[0]["scenario"] == "combined"
+
+
+def test_peak_memory_field_removed_flagged_for_condition() -> None:
+    """A baseline that reports median_peak_memory_gb against a new report that
+    dropped it should fail loud (the headline metric vanished)."""
+    from scripts.diff_showcase_report import diff_reports
+
+    old = _make_vs_vae_report(median_seconds=0.10, ssim_median=0.85)
+    new = _make_vs_vae_report(median_seconds=0.10, ssim_median=0.85)
+    del new["scenarios"]["taef2_vs_vae"]["taef"]["median_peak_memory_gb"]
+
+    regressions = diff_reports(old, new)
+    flagged = [
+        r for r in regressions if r["kind"] == "peak-memory-missing" and r["condition"] == "taef"
+    ]
+    assert len(flagged) == 1, f"expected a peak-memory-missing on taef, got {regressions}"
+
+
+def test_peak_memory_field_removed_flagged_for_scenario() -> None:
+    from scripts.diff_showcase_report import diff_reports
+
+    old = _make_live_report(elapsed_s=10.0)
+    new = _make_live_report(elapsed_s=10.0)
+    del new["scenarios"]["live_preview"]["peak_memory_gb"]
+
+    regressions = diff_reports(old, new)
+    flagged = [r for r in regressions if r["kind"] == "peak-memory-missing"]
+    assert len(flagged) == 1
+    assert flagged[0]["scenario"] == "live_preview"
+    assert flagged[0]["condition"] == "(scenario)"

--- a/tests/test_diff_showcase_report.py
+++ b/tests/test_diff_showcase_report.py
@@ -15,7 +15,13 @@ from pathlib import Path
 from typing import Any
 
 
-def _make_vs_vae_report(median_seconds: float, ssim_median: float) -> dict[str, Any]:
+def _make_vs_vae_report(
+    median_seconds: float,
+    ssim_median: float,
+    *,
+    taef_peak_gb: float = 0.59,
+    vae_peak_gb: float = 2.37,
+) -> dict[str, Any]:
     """Build a report shaped like run_showcase.py's `taef2_vs_vae` output."""
     return {
         "schema_version": 1,
@@ -26,12 +32,12 @@ def _make_vs_vae_report(median_seconds: float, ssim_median: float) -> dict[str, 
                 "taef": {
                     "condition": "taef2",
                     "median_seconds": median_seconds,
-                    "median_peak_memory_gb": 0.59,
+                    "median_peak_memory_gb": taef_peak_gb,
                 },
                 "vanilla_vae": {
                     "condition": "vanilla_vae",
                     "median_seconds": median_seconds * 8,  # vae is slower
-                    "median_peak_memory_gb": 2.37,
+                    "median_peak_memory_gb": vae_peak_gb,
                 },
                 "ssim_per_pair": [ssim_median],
                 "ssim_median": ssim_median,
@@ -40,7 +46,7 @@ def _make_vs_vae_report(median_seconds: float, ssim_median: float) -> dict[str, 
     }
 
 
-def _make_live_report(elapsed_s: float) -> dict[str, Any]:
+def _make_live_report(elapsed_s: float, *, peak_memory_gb: float = 10.0) -> dict[str, Any]:
     return {
         "schema_version": 1,
         "generated_at": "2026-05-26T00:00:00Z",
@@ -48,7 +54,29 @@ def _make_live_report(elapsed_s: float) -> dict[str, Any]:
             "live_preview": {
                 "status": "ok",
                 "elapsed_s": elapsed_s,
-                "peak_memory_gb": 10.0,
+                "peak_memory_gb": peak_memory_gb,
+            },
+        },
+    }
+
+
+def _make_combined_report(
+    *,
+    elapsed_s: float = 8.0,
+    peak_memory_gb: float = 7.9,
+    skipped_count: int = 1,
+) -> dict[str, Any]:
+    """Build a report shaped like run_showcase.py's `combined` scenario,
+    which carries the TeaCache `skipped_count` the integration headline depends on."""
+    return {
+        "schema_version": 1,
+        "generated_at": "2026-05-26T00:00:00Z",
+        "scenarios": {
+            "combined": {
+                "status": "ok",
+                "elapsed_s": elapsed_s,
+                "peak_memory_gb": peak_memory_gb,
+                "teacache": {"skipped_count": skipped_count},
             },
         },
     }
@@ -160,3 +188,110 @@ def test_self_diff_with_skewed_taef_value_finds_regression() -> None:
     regressions = diff_reports(old, new, wallclock_tolerance=0.10)
     flagged = [r for r in regressions if r.get("condition") == "taef"]
     assert flagged, f"expected a wallclock regression on taef, got {regressions}"
+
+
+# --- peak memory (the headline 5-7x memory win — must be guarded) ---
+
+
+def test_peak_memory_drift_above_threshold_flagged_for_taef() -> None:
+    """taef's peak decode memory creeping up past tolerance is a regression of
+    the library's headline claim, so the differ must flag it."""
+    from scripts.diff_showcase_report import diff_reports
+
+    old = _make_vs_vae_report(median_seconds=0.10, ssim_median=0.85, taef_peak_gb=0.59)
+    new = _make_vs_vae_report(median_seconds=0.10, ssim_median=0.85, taef_peak_gb=0.59 * 1.2)
+
+    regressions = diff_reports(old, new, memory_tolerance=0.10)
+    flagged = [
+        r for r in regressions if r["kind"] == "peak-memory-drift" and r["condition"] == "taef"
+    ]
+    assert len(flagged) == 1, f"expected a peak-memory-drift on taef, got {regressions}"
+
+
+def test_peak_memory_within_tolerance_reports_no_regression() -> None:
+    from scripts.diff_showcase_report import diff_reports
+
+    old = _make_vs_vae_report(median_seconds=0.10, ssim_median=0.85, taef_peak_gb=0.59)
+    new = _make_vs_vae_report(median_seconds=0.10, ssim_median=0.85, taef_peak_gb=0.59 * 1.05)
+
+    regressions = diff_reports(old, new, memory_tolerance=0.10)
+    assert [r for r in regressions if r["kind"] == "peak-memory-drift"] == []
+
+
+def test_peak_memory_drift_flagged_for_live_scenario() -> None:
+    """Live/combined scenarios carry scenario-level peak_memory_gb."""
+    from scripts.diff_showcase_report import diff_reports
+
+    old = _make_live_report(elapsed_s=10.0, peak_memory_gb=10.0)
+    new = _make_live_report(elapsed_s=10.0, peak_memory_gb=12.0)  # 20% up
+
+    regressions = diff_reports(old, new, memory_tolerance=0.10)
+    flagged = [r for r in regressions if r["kind"] == "peak-memory-drift"]
+    assert len(flagged) == 1
+    assert flagged[0]["scenario"] == "live_preview"
+    assert flagged[0]["condition"] == "(scenario)"
+
+
+# --- TeaCache skipped_count floor (combined integration must keep skipping) ---
+
+
+def test_skipped_count_drop_to_zero_flagged_for_combined() -> None:
+    """A TeaCache integration regression that stops skipping steps drops
+    combined.teacache.skipped_count to 0; the differ must flag it."""
+    from scripts.diff_showcase_report import diff_reports
+
+    old = _make_combined_report(skipped_count=1)
+    new = _make_combined_report(skipped_count=0)
+
+    regressions = diff_reports(old, new)
+    flagged = [r for r in regressions if r["kind"] == "skipped-count-drop"]
+    assert len(flagged) == 1, f"expected a skipped-count-drop, got {regressions}"
+    assert flagged[0]["scenario"] == "combined"
+
+
+def test_skipped_count_held_or_increased_reports_no_regression() -> None:
+    from scripts.diff_showcase_report import diff_reports
+
+    old = _make_combined_report(skipped_count=1)
+    for new_count in (1, 2):
+        new = _make_combined_report(skipped_count=new_count)
+        regressions = diff_reports(old, new)
+        assert [r for r in regressions if r["kind"] == "skipped-count-drop"] == []
+
+
+def test_self_diff_with_skewed_peak_memory_finds_regression() -> None:
+    """Integration: perturb the committed report's taef peak memory and verify
+    the differ catches it (proves it inspects the real median_peak_memory_gb)."""
+    from scripts.diff_showcase_report import diff_reports
+
+    report_path = Path(__file__).parent.parent / "_artifacts" / "showcase_report.json"
+    if not report_path.exists():
+        import pytest
+
+        pytest.skip(f"no committed showcase report at {report_path}")
+
+    old = json.loads(report_path.read_text())
+    new = json.loads(report_path.read_text())
+    new["scenarios"]["taef2_vs_vae"]["taef"]["median_peak_memory_gb"] *= 1.5
+    regressions = diff_reports(old, new)
+    flagged = [r for r in regressions if r["kind"] == "peak-memory-drift"]
+    assert flagged, f"expected a peak-memory regression, got {regressions}"
+
+
+def test_self_diff_with_zeroed_skipped_count_finds_regression() -> None:
+    """Integration: zero out the committed report's combined skipped_count and
+    verify the differ flags the TeaCache integration regression."""
+    from scripts.diff_showcase_report import diff_reports
+
+    report_path = Path(__file__).parent.parent / "_artifacts" / "showcase_report.json"
+    if not report_path.exists():
+        import pytest
+
+        pytest.skip(f"no committed showcase report at {report_path}")
+
+    old = json.loads(report_path.read_text())
+    new = json.loads(report_path.read_text())
+    new["scenarios"]["combined"]["teacache"]["skipped_count"] = 0
+    regressions = diff_reports(old, new)
+    flagged = [r for r in regressions if r["kind"] == "skipped-count-drop"]
+    assert flagged, f"expected a skipped-count-drop, got {regressions}"

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -80,7 +80,7 @@ def test_verify_conversion_coverage_raises_on_missing_param() -> None:
     from mlx_taef.convert import _verify_conversion_coverage
     from mlx_taef.errors import ConversionError
 
-    with pytest.raises(ConversionError, match="missing"):
+    with pytest.raises(ConversionError, match=r"missing \d+ expected parameter"):
         _verify_conversion_coverage({}, {"decoder.weight": (4, 4)})
 
 
@@ -131,5 +131,9 @@ def test_mlx_teacache_not_installed_default_message_mentions_install_path() -> N
     from mlx_taef.errors import MlxTeacacheNotInstalledError
 
     e = MlxTeacacheNotInstalledError()
-    assert "pip install" in str(e) or "uv add" in str(e)
-    assert "mlx-teacache" in str(e)
+    msg = str(e)
+    # both install hints are in the default message; assert both so dropping
+    # one is caught (an `or` could not detect a single hint going missing).
+    assert "pip install" in msg
+    assert "uv add" in msg
+    assert "mlx-teacache" in msg

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,6 +1,28 @@
-"""Exception-class structure tests."""
+"""Exception-class structure + raise-condition tests.
+
+The structure tests pin the hierarchy (a base-class change reds them). The
+raise-condition tests drive a real bad input through the real code path that
+raises each error, so a regression where a raise site throws a bare
+ImportError / KeyError instead of the package error would be caught — the
+declaration-only suite this replaced could not catch that.
+
+`MlxTeacacheNotInstalledError` has no raise site in the package today (a
+declared-but-unraised export — see backlog mlx-taef-0009), so it keeps the
+structure + default-message companion only; when a real raise site lands, a
+condition test belongs here next to the others.
+"""
 
 from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# --- structure: the hierarchy must hold (a base-class change reds these) ---
 
 
 def test_taef_error_is_base_exception() -> None:
@@ -13,6 +35,12 @@ def test_schema_version_error_subclasses_taef_error() -> None:
     from mlx_taef.errors import SchemaVersionError, TaefError
 
     assert issubclass(SchemaVersionError, TaefError)
+
+
+def test_conversion_error_subclasses_taef_error() -> None:
+    from mlx_taef.errors import ConversionError, TaefError
+
+    assert issubclass(ConversionError, TaefError)
 
 
 def test_mlx_teacache_not_installed_subclasses_taef_error_and_import_error() -> None:
@@ -29,16 +57,77 @@ def test_fixture_latent_missing_subclasses_taef_error_and_file_not_found() -> No
     assert issubclass(FixtureLatentMissingError, FileNotFoundError)
 
 
-def test_errors_reexported_from_package_root() -> None:
+def test_errors_reexported_from_package_root_by_identity() -> None:
+    """Re-export must be the SAME object. The old `is not None` check would
+    pass a wrong-object or `True` alias; identity catches a broken re-export.
+    Includes ConversionError, which the old check omitted entirely."""
     import mlx_taef
+    from mlx_taef import errors
 
-    assert mlx_taef.TaefError is not None
-    assert mlx_taef.SchemaVersionError is not None
-    assert mlx_taef.MlxTeacacheNotInstalledError is not None
-    assert mlx_taef.FixtureLatentMissingError is not None
+    assert mlx_taef.TaefError is errors.TaefError
+    assert mlx_taef.SchemaVersionError is errors.SchemaVersionError
+    assert mlx_taef.ConversionError is errors.ConversionError
+    assert mlx_taef.MlxTeacacheNotInstalledError is errors.MlxTeacacheNotInstalledError
+    assert mlx_taef.FixtureLatentMissingError is errors.FixtureLatentMissingError
 
 
-def test_mlx_teacache_not_installed_message_mentions_install_path() -> None:
+# --- raise conditions: a real bad input drives the real raise site ---
+
+
+def test_verify_conversion_coverage_raises_on_missing_param() -> None:
+    """An expected model parameter that no source key produced would load at
+    random init; conversion must raise rather than ship a wrong model."""
+    from mlx_taef.convert import _verify_conversion_coverage
+    from mlx_taef.errors import ConversionError
+
+    with pytest.raises(ConversionError, match="missing"):
+        _verify_conversion_coverage({}, {"decoder.weight": (4, 4)})
+
+
+def test_verify_conversion_coverage_raises_on_shape_mismatch() -> None:
+    """A produced parameter whose shape disagrees with the model would be
+    accepted verbatim; conversion must raise instead."""
+    import mlx.core as mx
+
+    from mlx_taef.convert import _verify_conversion_coverage
+    from mlx_taef.errors import ConversionError
+
+    converted = {"decoder.weight": mx.zeros((2, 2))}
+    with pytest.raises(ConversionError, match="shape mismatch"):
+        _verify_conversion_coverage(converted, {"decoder.weight": (4, 4)})
+
+
+def test_load_report_raises_on_unknown_schema_version(tmp_path: Path) -> None:
+    """Loading a report whose schema_version the code doesn't know must raise
+    rather than silently misinterpret fields."""
+    from scripts.run_showcase import SCHEMA_VERSION, _load_report
+
+    from mlx_taef.errors import SchemaVersionError
+
+    bad = tmp_path / "report.json"
+    bad.write_text(json.dumps({"schema_version": SCHEMA_VERSION + 1, "scenarios": {}}))
+    with pytest.raises(SchemaVersionError, match="schema_version"):
+        _load_report(bad)
+
+
+def test_check_latent_sha_raises_on_missing_latent(tmp_path: Path) -> None:
+    """A showcase scenario pointed at an absent fixture latent must raise the
+    package error, not a bare FileNotFoundError from somewhere downstream."""
+    from scripts.run_showcase import _check_latent_sha
+
+    from mlx_taef.errors import FixtureLatentMissingError
+
+    with pytest.raises(FixtureLatentMissingError, match="latent missing"):
+        _check_latent_sha(tmp_path / "absent_latent.npy")
+
+
+# --- MlxTeacacheNotInstalledError: no raise site yet (dead export, 0009) ---
+
+
+def test_mlx_teacache_not_installed_default_message_mentions_install_path() -> None:
+    """Companion to a (future) raise-condition test: pins the default install
+    hint. This error has no raise site in the package today (mlx-taef-0009), so
+    there is no real path to drive a bad input through yet."""
     from mlx_taef.errors import MlxTeacacheNotInstalledError
 
     e = MlxTeacacheNotInstalledError()


### PR DESCRIPTION
## v0.2.4 — internal hardening release

**No user-facing change.** Every change is in the test suite and developer tooling (`scripts/`); the published wheel (`src/mlx_taef`) is byte-identical to v0.2.3 apart from the version string. This marks the test + showcase-gate hardening from the 2026-06-02 tests review and this PR's own code review.

### What's in it
- **mlx-taef-0032** — the showcase regression gate (`scripts/diff_showcase_report.py`) now guards the headline peak-memory metric and the TeaCache `skipped_count` (it previously checked only wall-clock + SSIM), and — after this PR's review — also flags a baseline metric or block *disappearing* from a new report, not just a worse number. New `--memory-tolerance` (default 0.10).
- **mlx-taef-0033** — `tests/test_errors.py` now drives real bad inputs through each package error's raise site (was declaration-only); identity re-export check covering `ConversionError`; honest handling of the never-raised `MlxTeacacheNotInstalledError` (dead export, tracked as mlx-taef-0009).
- **mlx-taef-0038** — added the missing `_resolve_cap_gb` unknown-condition raise test. (The review's "8 untested raises in bench_decode.py" overcounted — the other raises were already covered in `tests/test_bench_decode.py` or are `# pragma: no cover`.)
- **Review follow-up** — closed the dropped-metric/block false-negative the 3-reviewer fan-out found in the original 0032 work (it caught `1 → 0` but not `1 → block-removed`, the spec's stated worst case).

Every new raise-condition / regression test was RED-first or mutation-verified.

### Test plan
Full CI gate green locally: `ruff check .`, `ruff format --check .`, `mypy src/mlx_taef`, `pytest --cov=mlx_taef --cov-fail-under=95 -m "not benchmark and not network"` → 166 passed, coverage 97.6%.

### Release step
hatch-vcs derives the version from the git tag, so the **v0.2.4 tag is cut post-merge** and triggers the PyPI publish via Trusted Publishing. That tag push needs explicit authorization and is not part of this PR.