### PR TITLE
v0.3.0: composable model-kernel refactor (no behavior change)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] — 2026-06-06
+
+Internal refactor. No change to the public API or to decoded output: `TAESD`,
+`TAESDXL`, `TAEF1`, `TAEF2`, `from_pretrained` / `from_pretrained_local`,
+`get_memory_cap_hint`, and imports from `mlx_taef.variants` all behave as before. The
+existing parity and SSIM fixtures gate the change bit-for-bit.
+
+### Changed
+- Each variant is now a composable model **kernel** (`mlx_taef.kernels`): a frozen
+  `ModelKernel` built from an `ArchSpec`, a `ConversionStrategy` (which owns the whole
+  HF→MLX conversion), a `LatentSpec`, a `WeightSource`, and an optional `MfluxBinding`.
+  Adding a model is now a self-contained kernel entry instead of edits spread across
+  `variants.py`, `api.py`, and `convert.py`. `variants.py` remains as a back-compat shim.
+- The converted-weights cache is keyed on the weight source (repo, filename, role)
+  rather than the variant name, so two models that share upstream weights share one cache
+  entry. Caches written by 0.2.x are ignored and rebuilt once on first run after upgrade.
+
+### Fixed
+- The mflux `LivePreviewCallback` FLUX.1 path. mflux hands the callback a packed
+  `(B, N, 64)` latent during the denoise loop; the previous code expected an already
+  unpacked `(B, 16, H, W)` and let the packed latent fall through to the decoder, so
+  FLUX.1 live previews came out wrong. The callback now unpacks per model via the kernel
+  binding, reproducing mflux's own `unpack_latents`, with a test that pins the result
+  against that function.
+
 ## [0.2.4] — 2026-06-03
 
 Internal hardening only. No change to the library API, runtime behavior, or the

--- a/src/mlx_taef/__init__.py
+++ b/src/mlx_taef/__init__.py
@@ -9,6 +9,7 @@ from mlx_taef.errors import (
     MlxTeacacheNotInstalledError,
     SchemaVersionError,
     TaefError,
+    UnknownKernelError,
 )
 from mlx_taef.variants import get_memory_cap_hint
 
@@ -23,6 +24,7 @@ __all__ = [
     "SchemaVersionError",
     "Taef",
     "TaefError",
+    "UnknownKernelError",
     "get_memory_cap_hint",
 ]
 

--- a/src/mlx_taef/api.py
+++ b/src/mlx_taef/api.py
@@ -11,45 +11,47 @@ from typing import cast
 import mlx.core as mx
 import mlx.nn as nn
 
-from mlx_taef.model import make_decoder, make_encoder
-from mlx_taef.variants import (
-    TAEF1_CONFIG,
-    TAEF2_CONFIG,
-    TAESD_CONFIG,
-    TAESDXL_CONFIG,
-    TaesdVariantConfig,
-)
+from mlx_taef.kernels import KERNELS, MIDBLOCK_GN, ModelKernel
+from mlx_taef.kernels._arch import build_arch
 
 logger = logging.getLogger(__name__)
 
 
 class Taef(nn.Module):  # type: ignore[misc,name-defined]
-    """Base class for TAESD-family models.
+    """Base class for TAESD-family models. Subclasses set `_kernel`."""
 
-    Subclasses set the `_config` class variable to a `TaesdVariantConfig`.
-
-    Args:
-        None — instantiated via `from_pretrained_local(path)`.
-
-    Tensor layout:
-        All public methods use NHWC `mx.array`:
-        - latent shape: (B, H, W, latent_channels)
-        - image shape: (B, H*8, W*8, 3)
-
-    Value space:
-        - `decode()` returns float in [0, 1] (clipped on output).
-        - `decode_image()` returns uint8 in [0, 255].
-        - Latents are RAW (post-Clamp scale), values roughly in [-3, 3].
-        - `scale_latents` / `unscale_latents` convert between raw and [0, 1].
-    """
-
-    _config: TaesdVariantConfig
+    _kernel: ModelKernel
 
     def __init__(self) -> None:
-        """Initialise decoder and encoder from the subclass `_config`."""
+        """Build decoder + encoder from `self._kernel`."""
         super().__init__()
-        self.decoder = make_decoder(self._config)
-        self.encoder = make_encoder(self._config)
+        ch = self._kernel.latent.channels
+        mbgn = MIDBLOCK_GN.get(self._kernel.name, False)
+        self.decoder = build_arch(
+            self._kernel.arch.name, role="decoder", latent_channels=ch, midblock_gn=mbgn
+        )
+        self.encoder = build_arch(
+            self._kernel.arch.name, role="encoder", latent_channels=ch, midblock_gn=mbgn
+        )
+
+    @classmethod
+    def from_kernel(
+        cls,
+        kernel: ModelKernel,
+        *,
+        decoder_path: Path | str,
+        encoder_path: Path | str | None = None,
+        dtype: mx.Dtype = mx.float32,
+    ) -> "Taef":
+        """Build an instance bound to `kernel` and load converted MLX weights from disk."""
+
+        class _Bound(cls):  # type: ignore[valid-type, misc]
+            _kernel = kernel
+
+        return cast(
+            "Taef",
+            _Bound.from_pretrained_local(decoder_path, encoder_path=encoder_path, dtype=dtype),
+        )
 
     @classmethod
     def from_pretrained_local(
@@ -59,23 +61,8 @@ class Taef(nn.Module):  # type: ignore[misc,name-defined]
         *,
         dtype: mx.Dtype = mx.float32,
     ) -> "Taef":
-        """Instantiate from already-converted MLX safetensors on disk.
-
-        Args:
-            decoder_path: path to converted MLX decoder safetensors.
-            encoder_path: optional path to converted MLX encoder safetensors (Phase 2).
-            dtype: target dtype for model weights. Default fp32 to keep parity tests sharp.
-
-        Returns:
-            A loaded `Taef` instance ready for `decode()`.
-        """
+        """Instantiate from already-converted MLX safetensors on disk."""
         instance = cls()
-        # Load each submodule with strict=True so a dropped or wrong-shaped weight
-        # raises instead of leaving a parameter at random init (silently-wrong
-        # image). Loading per-submodule — rather than the whole instance — keeps
-        # decoder-only loading valid: the encoder simply stays at init when no
-        # encoder_path is given, instead of tripping a top-level strict check on
-        # the (legitimately absent) encoder parameters.
         d_weights = cast("dict[str, mx.array]", mx.load(str(decoder_path)))
         instance.decoder.load_weights(list(d_weights.items()), strict=True)
         if encoder_path is not None:
@@ -94,114 +81,64 @@ class Taef(nn.Module):  # type: ignore[misc,name-defined]
         dtype: mx.Dtype = mx.float32,
         include_encoder: bool = True,
     ) -> "Taef":
-        """Auto-download weights from HF Hub, convert to MLX, and load.
-
-        On first call, downloads upstream weights from `cls._config.hf_repo` and
-        caches converted output at ~/.cache/mlx-taef/. Subsequent calls return
-        instantly from cache.
-
-        Args:
-            repo_id: optional HF repo override. If set, must match `cls._config.hf_repo`.
-            dtype: target dtype for weights. Default fp32 to keep parity strict.
-            include_encoder: whether to also load the encoder side (default True).
-
-        Returns:
-            A loaded `Taef` instance.
-        """
+        """Auto-download weights from HF Hub, convert to MLX, and load."""
         from mlx_taef.download import get_or_convert
 
-        config = cls._config
-        if repo_id is not None and repo_id != config.hf_repo:
+        kernel = cls._kernel
+        if repo_id is not None and repo_id != kernel.source.repo:
             raise ValueError(
-                f"repo_id mismatch: requested {repo_id!r} but variant {config.name!r} "
-                f"uses {config.hf_repo!r}"
+                f"repo_id mismatch: requested {repo_id!r} but kernel {kernel.name!r} "
+                f"uses {kernel.source.repo!r}"
             )
-        decoder_path = get_or_convert(config, role="decoder")
-        encoder_path = get_or_convert(config, role="encoder") if include_encoder else None
+        decoder_path = get_or_convert(kernel, role="decoder")
+        encoder_path = get_or_convert(kernel, role="encoder") if include_encoder else None
         return cls.from_pretrained_local(decoder_path, encoder_path=encoder_path, dtype=dtype)
 
     def decode(self, latents: mx.array) -> mx.array:
-        """Decode raw latents (NHWC) to image (NHWC, [0, 1] float).
-
-        Args:
-            latents: NHWC array with shape (B, H, W, latent_channels).
-
-        Returns:
-            NHWC float array with shape (B, H*8, W*8, 3), values in [0, 1].
-        """
-        out = self.decoder(latents)
-        return mx.clip(out, 0.0, 1.0)
+        """Decode raw latents (NHWC) to image (NHWC, [0, 1] float)."""
+        return mx.clip(self.decoder(latents), 0.0, 1.0)
 
     def decode_image(self, latents: mx.array) -> mx.array:
-        """Decode raw latents to a uint8 NHWC image suitable for PIL/PNG.
-
-        Args:
-            latents: NHWC array with shape (B, H, W, latent_channels).
-
-        Returns:
-            NHWC uint8 array with shape (B, H*8, W*8, 3), values in [0, 255].
-        """
-        img_float = self.decode(latents)
-        return (img_float * 255.0).astype(mx.uint8)
+        """Decode raw latents to a uint8 NHWC image suitable for PIL/PNG."""
+        return (self.decode(latents) * 255.0).astype(mx.uint8)
 
     def encode(self, image: mx.array) -> mx.array:
-        """Encode an NHWC RGB image (B, H, W, 3) in [0, 1] to a latent (B, H/8, W/8, latent_channels).
-
-        Args:
-            image: NHWC float array with shape (B, H, W, 3), values in [0, 1].
-
-        Returns:
-            NHWC latent array with shape (B, H/8, W/8, latent_channels).
-        """
+        """Encode an NHWC RGB image (B,H,W,3) in [0,1] to a latent (B,H/8,W/8,channels)."""
         return cast("mx.array", self.encoder(image))
 
     def scale_latents(self, raw: mx.array) -> mx.array:
-        """Map raw latents to [0, 1] using config.latent_magnitude/shift.
-
-        Args:
-            raw: raw latent array, values roughly in [-3, 3].
-
-        Returns:
-            Scaled latent array clipped to [0, 1].
-        """
-        c = self._config
-        return mx.clip(raw / (2.0 * c.latent_magnitude) + c.latent_shift, 0.0, 1.0)
+        """Map raw latents to [0, 1] using the kernel's latent magnitude/shift."""
+        ls = self._kernel.latent
+        return mx.clip(raw / (2.0 * ls.magnitude) + ls.shift, 0.0, 1.0)
 
     def unscale_latents(self, scaled: mx.array) -> mx.array:
-        """Inverse of scale_latents: [0, 1] -> raw.
-
-        Args:
-            scaled: latent array in [0, 1].
-
-        Returns:
-            Raw latent array.
-        """
-        c = self._config
-        return (scaled - c.latent_shift) * (2.0 * c.latent_magnitude)
+        """Inverse of scale_latents: [0, 1] -> raw."""
+        ls = self._kernel.latent
+        return (scaled - ls.shift) * (2.0 * ls.magnitude)
 
 
 class TAESD(Taef):
     """TAESD for Stable Diffusion 1.x."""
 
-    _config = TAESD_CONFIG
+    _kernel = KERNELS["taesd"]
 
 
 class TAESDXL(Taef):
     """TAESD for SDXL."""
 
-    _config = TAESDXL_CONFIG
+    _kernel = KERNELS["taesdxl"]
 
 
 class TAEF1(Taef):
     """TAEF1 for FLUX.1."""
 
-    _config = TAEF1_CONFIG
+    _kernel = KERNELS["taef1"]
 
 
 class TAEF2(Taef):
     """TAEF2 for FLUX.2 Klein."""
 
-    _config = TAEF2_CONFIG
+    _kernel = KERNELS["taef2"]
 
 
 __all__ = ["TAEF1", "TAEF2", "TAESD", "TAESDXL", "Taef"]

--- a/src/mlx_taef/cli.py
+++ b/src/mlx_taef/cli.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import mlx.core as mx
 
-from mlx_taef.variants import ALL_VARIANTS
+from mlx_taef.kernels import KERNELS
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +20,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     sub = parser.add_subparsers(dest="cmd", required=True)
 
-    variant_names = [v.name for v in ALL_VARIANTS]
+    variant_names = sorted(KERNELS)
 
     p_convert = sub.add_parser("convert", help="Download upstream weights and convert to MLX")
     p_convert.add_argument("--variant", required=True, choices=variant_names)
@@ -45,8 +45,9 @@ def main(argv: list[str] | None = None) -> int:
 
 def _cmd_convert(args: argparse.Namespace) -> int:  # pragma: no cover
     from mlx_taef.convert import convert_hf_decoder_to_mlx, convert_hf_encoder_to_mlx
+    from mlx_taef.variants import VARIANTS
 
-    config = next(v for v in ALL_VARIANTS if v.name == args.variant)
+    config = VARIANTS[args.variant]
     if args.role == "encoder":
         convert_hf_encoder_to_mlx(out_path=args.dst, config=config)
     else:
@@ -69,11 +70,10 @@ def _cmd_bench(args: argparse.Namespace) -> int:  # pragma: no cover
 
     cls_by_name = {"taesd": TAESD, "taesdxl": TAESDXL, "taef1": TAEF1, "taef2": TAEF2}
     cls = cls_by_name[args.variant]
-    config = next(v for v in ALL_VARIANTS if v.name == args.variant)
 
     model = cls.from_pretrained(include_encoder=False)
     # 1024x1024 image with 8x downsample = 128x128 latent
-    latent = mx.random.normal((1, 128, 128, config.latent_channels)).astype(mx.float16)
+    latent = mx.random.normal((1, 128, 128, cls._kernel.latent.channels)).astype(mx.float16)
     mx.eval(latent)
 
     # Warm-up

--- a/src/mlx_taef/download.py
+++ b/src/mlx_taef/download.py
@@ -3,42 +3,38 @@
 import logging
 from pathlib import Path
 
-from mlx_taef.convert import convert_hf_decoder_to_mlx, convert_hf_encoder_to_mlx
-from mlx_taef.variants import TaesdVariantConfig
+import mlx.core as mx
+
+from mlx_taef.kernels import MIDBLOCK_GN, ModelKernel
+from mlx_taef.kernels._arch import build_arch
 
 logger = logging.getLogger(__name__)
 
 CACHE_ROOT = Path.home() / ".cache" / "mlx-taef"
 
 
-def get_or_convert(config: TaesdVariantConfig, *, role: str = "decoder") -> Path:
-    """Return the local path to converted MLX weights for (variant, role).
+def get_or_convert(kernel: ModelKernel, *, role: str = "decoder") -> Path:
+    """Return the local path to converted MLX weights for (kernel, role).
 
-    On cache miss, triggers the full conversion pipeline (HF download + key
-    remap + NHWC transpose + safetensors write). Subsequent calls return the
-    cached path without any network access.
-
-    Args:
-        config: variant configuration (selects HF repo + filename).
-        role: 'decoder' (default) or 'encoder'.
-
-    Returns:
-        Local filesystem path to the MLX safetensors file.
+    Cache is keyed on the weight SOURCE identity (repo + filename + role), not the kernel
+    name, so kernels that share upstream weights (e.g. zimage -> taef1) share one converted
+    file while a model's decoder/encoder never collide.
     """
-    cache_dir = CACHE_ROOT / config.name
+    if role not in ("decoder", "encoder"):
+        raise ValueError(f"role must be 'decoder' or 'encoder', got {role!r}")
+    cache_dir = CACHE_ROOT / "converted"
     cache_dir.mkdir(parents=True, exist_ok=True)
-    out_path = cache_dir / f"{config.name}_{role}.safetensors"
+    out_path = cache_dir / f"{kernel.source.cache_key(role=role)}.mlx.safetensors"
     if out_path.exists():
         logger.debug("Using cached weights at %s", out_path)
         return out_path
 
-    logger.info("Downloading + converting %s %s weights from %s", config.name, role, config.hf_repo)
-    if role == "decoder":
-        convert_hf_decoder_to_mlx(out_path=out_path, config=config)
-    elif role == "encoder":
-        convert_hf_encoder_to_mlx(out_path=out_path, config=config)
-    else:
-        raise ValueError(f"role must be 'decoder' or 'encoder', got {role!r}")
+    logger.info("Downloading + converting %s %s from %s", kernel.name, role, kernel.source.repo)
+    ch = kernel.latent.channels
+    mbgn = MIDBLOCK_GN.get(kernel.name, False)
+    arch_module = build_arch(kernel.arch.name, role=role, latent_channels=ch, midblock_gn=mbgn)
+    converted = kernel.conversion.convert(kernel.source, arch_module, role=role)
+    mx.save_safetensors(str(out_path), converted)
     return out_path
 
 

--- a/src/mlx_taef/errors.py
+++ b/src/mlx_taef/errors.py
@@ -5,7 +5,8 @@ Hierarchy:
     ├── SchemaVersionError                 unknown JSON schema_version
     ├── ConversionError                    HF->MLX conversion dropped/mis-shaped a param
     ├── MlxTeacacheNotInstalledError       (+ ImportError) optional dep missing
-    └── FixtureLatentMissingError          (+ FileNotFoundError) showcase fixture absent
+    ├── FixtureLatentMissingError          (+ FileNotFoundError) showcase fixture absent
+    └── UnknownKernelError                 (+ KeyError) name not in the kernel registry
 """
 
 from __future__ import annotations
@@ -53,3 +54,7 @@ class MlxTeacacheNotInstalledError(TaefError, ImportError):
 
 class FixtureLatentMissingError(TaefError, FileNotFoundError):
     """Raised when a showcase scenario's fixture latent file is missing."""
+
+
+class UnknownKernelError(TaefError, KeyError):
+    """Raised when a kernel name is not in the registry."""

--- a/src/mlx_taef/integrations/mflux.py
+++ b/src/mlx_taef/integrations/mflux.py
@@ -211,7 +211,7 @@ class LivePreviewCallback(InLoopCallback):  # type: ignore[misc]
         if idx % self.every != 0:
             return  # pragma: no cover
 
-        if self.model._config.name == "taef2":
+        if self.model._kernel.name == "taef2":
             unpacked = unpack_flux2_latent(
                 latents,
                 latent_height=self.latent_height,

--- a/src/mlx_taef/integrations/mflux.py
+++ b/src/mlx_taef/integrations/mflux.py
@@ -47,8 +47,11 @@ def unpack_flux2_latent(
     from mlx_taef.kernels.flux import unpack_flux2_latent as _kernel_unpack
 
     ctx = UnpackContext(
-        latent_height=latent_height, latent_width=latent_width,
-        bn_mean=bn_mean, bn_var=bn_var, bn_eps=bn_eps,
+        latent_height=latent_height,
+        latent_width=latent_width,
+        bn_mean=bn_mean,
+        bn_var=bn_var,
+        bn_eps=bn_eps,
     )
     return _kernel_unpack(packed, ctx)
 

--- a/src/mlx_taef/integrations/mflux.py
+++ b/src/mlx_taef/integrations/mflux.py
@@ -37,52 +37,20 @@ def unpack_flux2_latent(
     bn_var: mx.array | None = None,
     bn_eps: float = 1e-4,
 ) -> mx.array:
-    """Unpack mflux's packed FLUX.2 latent into NHWC `(B, lH*2, lW*2, 32)` for TAEF2.
+    """Back-compat keyword API for the FLUX.2 unpack; delegates to the kernel unpack.
 
-    Mirrors mflux's `Flux2VAE.decode_packed_latents` preprocessing:
-    1. BN denormalize: latents = packed * sqrt(var + eps) + mean  (128-channel stats)
-    2. Unpatchify: (B, 128, lH, lW) -> (B, 32, lH*2, lW*2)
-    3. NCHW -> NHWC transpose.
-
-    Without `bn_mean`/`bn_var`, the helper assumes identity BN (correct shape,
-    slight value offset). Preview structure will still be visible but colors
-    may shift. For exact preview, pass the BN stats from the loaded Flux2VAE.
-
-    Args:
-        packed: in-loop latent from mflux, shape (B, lH*lW, 128).
-        latent_height: latent spatial height (image_height // 16).
-        latent_width: latent spatial width.
-        bn_mean: optional BN running_mean for exact value recovery (128 elements).
-        bn_var: optional BN running_var for exact value recovery (128 elements).
-        bn_eps: BN epsilon. Matches mflux's Flux2BatchNormStats default of 1e-4,
-            verified at mflux 0.17.5.
-
-    Returns:
-        NHWC tensor of shape (B, latent_height*2, latent_width*2, 32) — ready
-        for `TAEF2.decode()`.
+    The canonical implementation now lives in `mlx_taef.kernels.flux.unpack_flux2_latent`
+    with the `(latent, UnpackContext)` signature; this wrapper preserves the original
+    keyword call shape for existing callers.
     """
-    b, _, c = packed.shape
-    if c != 128:
-        raise ValueError(f"Expected 128-channel packed latent, got {c}")
+    from mlx_taef.kernels import UnpackContext
+    from mlx_taef.kernels.flux import unpack_flux2_latent as _kernel_unpack
 
-    # Step 1: reshape and transpose to NCHW: (B, lH*lW, 128) -> (B, lH, lW, 128) -> (B, 128, lH, lW)
-    latents = packed.reshape(b, latent_height, latent_width, c).transpose(0, 3, 1, 2)
-
-    # Step 2: BN denormalize
-    if bn_mean is not None and bn_var is not None:
-        mean = bn_mean.reshape(1, -1, 1, 1)
-        std = mx.sqrt(bn_var.reshape(1, -1, 1, 1) + bn_eps)
-        latents = latents * std + mean
-    # else: identity BN (mean=0, var=1)
-
-    # Step 3: Unpatchify (B, 128, lH, lW) -> (B, 32, lH*2, lW*2)
-    batch, _, h, w = latents.shape
-    latents = latents.reshape(batch, 32, 2, 2, h, w)
-    latents = latents.transpose(0, 1, 4, 2, 5, 3)
-    latents = latents.reshape(batch, 32, h * 2, w * 2)
-
-    # Step 4: NCHW -> NHWC for TAEF2
-    return latents.transpose(0, 2, 3, 1)
+    ctx = UnpackContext(
+        latent_height=latent_height, latent_width=latent_width,
+        bn_mean=bn_mean, bn_var=bn_var, bn_eps=bn_eps,
+    )
+    return _kernel_unpack(packed, ctx)
 
 
 def _try_extract_bn(flux: object) -> tuple[mx.array | None, mx.array | None]:
@@ -211,19 +179,18 @@ class LivePreviewCallback(InLoopCallback):  # type: ignore[misc]
         if idx % self.every != 0:
             return  # pragma: no cover
 
-        if self.model._kernel.name == "taef2":
-            unpacked = unpack_flux2_latent(
-                latents,
-                latent_height=self.latent_height,
-                latent_width=self.latent_width,
-                bn_mean=self.bn_mean,
-                bn_var=self.bn_var,
-            )
-        else:  # pragma: no cover
-            # TAEF1 / FLUX.1: latents come in NCHW (B, 16, H, W). Transpose to NHWC.
-            unpacked = mx.transpose(latents, (0, 2, 3, 1)) if latents.shape[1] == 16 else latents
+        from mlx_taef.kernels import UnpackContext
 
-        img = self.model.decode_image(unpacked)
+        binding = self.model._kernel.integration
+        if binding is None:
+            raise ValueError(f"kernel {self.model._kernel.name!r} has no mflux binding")
+        ctx = UnpackContext(
+            latent_height=self.latent_height,
+            latent_width=self.latent_width,
+            bn_mean=self.bn_mean,
+            bn_var=self.bn_var,
+        )
+        img = self.model.decode_image(binding.unpack(latents, ctx))
         target = self._resolve_target(idx)
         self._save_image(img[0], target)
         self.saved_paths.append(target)

--- a/src/mlx_taef/kernels/__init__.py
+++ b/src/mlx_taef/kernels/__init__.py
@@ -1,0 +1,1 @@
+"""Model-kernel package: one self-contained kernel per supported model."""

--- a/src/mlx_taef/kernels/__init__.py
+++ b/src/mlx_taef/kernels/__init__.py
@@ -1,1 +1,44 @@
 """Model-kernel package: one self-contained kernel per supported model."""
+
+from types import MappingProxyType
+
+from mlx_taef.errors import UnknownKernelError
+from mlx_taef.kernels._types import (
+    ArchSpec,
+    LatentSpec,
+    MfluxBinding,
+    ModelKernel,
+    UnpackContext,
+    WeightSource,
+)
+from mlx_taef.kernels.flux import TAEF1, TAEF2
+from mlx_taef.kernels.sd import TAESD, TAESDXL
+
+# Per-kernel arch builder knobs that are NOT on the shared ArchSpec record.
+MIDBLOCK_GN: MappingProxyType[str, bool] = MappingProxyType(
+    {"taesd": False, "taesdxl": False, "taef1": False, "taef2": True}
+)
+
+_ALL = (TAESD, TAESDXL, TAEF1, TAEF2)
+KERNELS: MappingProxyType[str, ModelKernel] = MappingProxyType({k.name: k for k in _ALL})
+
+
+def get_kernel(name: str) -> ModelKernel:
+    """Return the kernel registered under `name`, or raise `UnknownKernelError`."""
+    try:
+        return KERNELS[name]
+    except KeyError as e:
+        raise UnknownKernelError(f"unknown kernel: {name!r}") from e
+
+
+__all__ = [
+    "KERNELS",
+    "MIDBLOCK_GN",
+    "ArchSpec",
+    "LatentSpec",
+    "MfluxBinding",
+    "ModelKernel",
+    "UnpackContext",
+    "WeightSource",
+    "get_kernel",
+]

--- a/src/mlx_taef/kernels/_arch.py
+++ b/src/mlx_taef/kernels/_arch.py
@@ -1,0 +1,75 @@
+"""Named architecture builders. A kernel's `ArchSpec.name` selects one of these.
+
+`taesd2d` is the shared TAESD-family 2D image arch (TAESD/TAESDXL/TAEF1/TAEF2). Builder
+knobs (latent_channels, midblock_gn) are passed at build time — they do NOT live on the
+shared `ArchSpec` record.
+"""
+
+from collections.abc import Callable
+
+import mlx.nn as nn
+
+from mlx_taef.model import Block, Clamp, make_conv
+
+
+def _build_taesd2d_decoder(latent_channels: int, *, midblock_gn: bool) -> "nn.Sequential":  # type: ignore[name-defined]
+    layers: list[nn.Module] = [  # type: ignore[name-defined]
+        Clamp(),
+        make_conv(latent_channels, 64),
+        nn.ReLU(),  # type: ignore[attr-defined]
+        Block(64, 64, use_midblock_gn=midblock_gn),
+        Block(64, 64, use_midblock_gn=midblock_gn),
+        Block(64, 64, use_midblock_gn=midblock_gn),
+        nn.Upsample(scale_factor=2, mode="nearest"),  # type: ignore[attr-defined]
+        make_conv(64, 64, bias=False),
+        Block(64, 64),
+        Block(64, 64),
+        Block(64, 64),
+        nn.Upsample(scale_factor=2, mode="nearest"),  # type: ignore[attr-defined]
+        make_conv(64, 64, bias=False),
+        Block(64, 64),
+        Block(64, 64),
+        Block(64, 64),
+        nn.Upsample(scale_factor=2, mode="nearest"),  # type: ignore[attr-defined]
+        make_conv(64, 64, bias=False),
+        Block(64, 64),
+        make_conv(64, 3),
+    ]
+    return nn.Sequential(*layers)  # type: ignore[attr-defined]
+
+
+def _build_taesd2d_encoder(latent_channels: int, *, midblock_gn: bool) -> "nn.Sequential":  # type: ignore[name-defined]
+    layers: list[nn.Module] = [  # type: ignore[name-defined]
+        make_conv(3, 64),
+        Block(64, 64),
+        make_conv(64, 64, stride=2, bias=False),
+        Block(64, 64),
+        Block(64, 64),
+        Block(64, 64),
+        make_conv(64, 64, stride=2, bias=False),
+        Block(64, 64),
+        Block(64, 64),
+        Block(64, 64),
+        make_conv(64, 64, stride=2, bias=False),
+        Block(64, 64, use_midblock_gn=midblock_gn),
+        Block(64, 64, use_midblock_gn=midblock_gn),
+        Block(64, 64, use_midblock_gn=midblock_gn),
+        make_conv(64, latent_channels),
+    ]
+    return nn.Sequential(*layers)  # type: ignore[attr-defined]
+
+
+ARCH_BUILDERS: dict[str, dict[str, Callable[..., nn.Sequential]]] = {  # type: ignore[name-defined]
+    "taesd2d": {"decoder": _build_taesd2d_decoder, "encoder": _build_taesd2d_encoder},
+}
+
+
+def build_arch(
+    arch_name: str, *, role: str, latent_channels: int, midblock_gn: bool
+) -> "nn.Sequential":  # type: ignore[name-defined]
+    """Build the encoder/decoder for `arch_name` with the given channel count + knobs."""
+    try:
+        builder = ARCH_BUILDERS[arch_name][role]
+    except KeyError as e:
+        raise KeyError(f"unknown arch/role: {arch_name!r}/{role!r}") from e
+    return builder(latent_channels, midblock_gn=midblock_gn)

--- a/src/mlx_taef/kernels/_conversion.py
+++ b/src/mlx_taef/kernels/_conversion.py
@@ -1,0 +1,68 @@
+"""Conversion strategies: own the full HF->MLX conversion for a weight source.
+
+Each strategy downloads + key-remaps the source weights, then applies the shared
+NCHW->NHWC transpose + coverage-verify (introspecting the built arch module), returning the
+arch-shaped MLX state dict. Divergent architectures supply a new strategy here rather than
+editing shared convert internals.
+
+The `from mlx_taef.convert import ...` calls are deferred into the methods: importing them at
+module load creates a cycle (kernels.__init__ -> flux -> _conversion -> convert -> model ->
+variants(shim) -> kernels.KERNELS, which is not yet bound).
+"""
+
+import mlx.core as mx
+import numpy as np
+
+from mlx_taef.kernels._types import WeightSource
+
+
+class DiffusersRemap:
+    """Diffusers single-file source (FLUX.1/FLUX.2/Z-Image). Decoder keys get a +1 offset."""
+
+    def _load_raw(self, source: WeightSource, role: str) -> dict[str, np.ndarray]:
+        """Download + key-remap the diffusers single-file source to Sequential keys."""
+        from huggingface_hub import hf_hub_download  # pragma: no cover
+        from safetensors.numpy import load_file as safetensors_load_numpy  # pragma: no cover
+
+        from mlx_taef.convert import convert_diffusers_to_sequential  # pragma: no cover
+
+        if source.filename is None:  # pragma: no cover
+            raise ValueError(f"Diffusers source {source.repo!r} has no filename")
+        path = hf_hub_download(repo_id=source.repo, filename=source.filename)  # pragma: no cover
+        full_sd = safetensors_load_numpy(path)  # pragma: no cover
+        return convert_diffusers_to_sequential(full_sd, role=role)  # pragma: no cover
+
+    def convert(
+        self, source: WeightSource, arch_module: object, *, role: str
+    ) -> dict[str, mx.array]:
+        """Convert the diffusers source for `role` into the arch-shaped MLX state dict."""
+        from mlx_taef.convert import _build_mlx_state_dict, _flatten_module_param_shapes
+
+        raw = self._load_raw(source, role)
+        expected = _flatten_module_param_shapes(arch_module)
+        return _build_mlx_state_dict(raw, expected_shapes=expected)
+
+
+class UpstreamTwoFile:
+    """Upstream two-file source (TAESD/TAESDXL): separate decoder/encoder safetensors."""
+
+    def _load_raw(self, source: WeightSource, role: str) -> dict[str, np.ndarray]:
+        """Download the upstream per-role safetensors (already Sequential-keyed)."""
+        from huggingface_hub import hf_hub_download  # pragma: no cover
+        from safetensors.numpy import load_file as safetensors_load_numpy  # pragma: no cover
+
+        fname = source.decoder_filename if role == "decoder" else source.encoder_filename
+        if fname is None:  # pragma: no cover
+            raise ValueError(f"Upstream source {source.repo!r} has no {role} filename")
+        path = hf_hub_download(repo_id=source.repo, filename=fname)  # pragma: no cover
+        return safetensors_load_numpy(path)  # pragma: no cover
+
+    def convert(
+        self, source: WeightSource, arch_module: object, *, role: str
+    ) -> dict[str, mx.array]:
+        """Convert the upstream source for `role` into the arch-shaped MLX state dict."""
+        from mlx_taef.convert import _build_mlx_state_dict, _flatten_module_param_shapes
+
+        raw = self._load_raw(source, role)
+        expected = _flatten_module_param_shapes(arch_module)
+        return _build_mlx_state_dict(raw, expected_shapes=expected)

--- a/src/mlx_taef/kernels/_types.py
+++ b/src/mlx_taef/kernels/_types.py
@@ -1,0 +1,111 @@
+"""Composable model-kernel types.
+
+A `ModelKernel` is a frozen record of small strategy objects: an `ArchSpec` (names a shared
+arch builder), a `ConversionStrategy` (owns the full HF->MLX conversion), a `LatentSpec`
+(latent metadata), a `WeightSource` (where upstream weights live + how they cache), and an
+optional `MfluxBinding` (which mflux models it previews + how to unpack their in-loop latent).
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Protocol
+
+import mlx.core as mx
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class LatentSpec:
+    """Latent metadata (scalar scale/shift; FLUX/Z-Image form).
+
+    A per-channel-stats variant is added in Phase 3 (Qwen/Wan) when that contract is known.
+    """
+
+    channels: int
+    magnitude: float = 3.0
+    shift: float = 0.5
+    downsample: int = 8
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ArchSpec:
+    """Names a shared architecture builder.
+
+    Channel count flows from `LatentSpec` into the builder at construction; builder-specific
+    knobs live builder-local, not here.
+    """
+
+    name: str
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class WeightSource:
+    """Upstream weights location + cache identity.
+
+    `cache_key` derives from (repo, filename, role) — NOT the kernel name — so kernels that
+    share source weights (e.g. zimage -> taef1) share one converted-cache entry, while a
+    model's decoder and encoder never collide (single-file sources reuse one filename).
+    """
+
+    repo: str
+    filename: str | None = None
+    decoder_filename: str | None = None
+    encoder_filename: str | None = None
+
+    def cache_key(self, *, role: str) -> str:
+        """Return a stable cache filename stem for (this weight source, role)."""
+        if self.filename is not None:
+            fname = self.filename
+        elif role == "decoder":
+            fname = self.decoder_filename or ""
+        else:
+            fname = self.encoder_filename or ""
+        return f"{self.repo.replace('/', '_')}__{fname}__{role}"
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class UnpackContext:
+    """Everything an unpack callable may need, assembled once by the callback.
+
+    The callback itself does zero model-name branching.
+    """
+
+    latent_height: int
+    latent_width: int
+    bn_mean: mx.array | None = None
+    bn_var: mx.array | None = None
+    bn_eps: float = 1e-4
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class MfluxBinding:
+    """Binds a kernel to the mflux model(s) it previews and how to unpack their latent."""
+
+    mflux_models: tuple[str, ...]
+    unpack: Callable[[mx.array, UnpackContext], mx.array]
+
+
+class ConversionStrategy(Protocol):
+    """Owns the full HF->MLX conversion.
+
+    Handles download + key-remap + NCHW->NHWC transpose + coverage-verify,
+    returning the arch-shaped MLX state dict.
+    """
+
+    def convert(
+        self, source: WeightSource, arch_module: object, *, role: str
+    ) -> dict[str, mx.array]:
+        """Convert the source weights for `role` into the arch-shaped MLX state dict."""
+        ...
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ModelKernel:
+    """One self-contained model: arch + conversion + latent + weights + mflux binding."""
+
+    name: str
+    arch: ArchSpec
+    conversion: ConversionStrategy
+    latent: LatentSpec
+    source: WeightSource
+    integration: MfluxBinding | None = None
+    memory_cap_hint_gb: int | None = None

--- a/src/mlx_taef/kernels/flux.py
+++ b/src/mlx_taef/kernels/flux.py
@@ -1,0 +1,79 @@
+"""FLUX.1 / FLUX.2 model kernels and their mflux latent unpacks."""
+
+import mlx.core as mx
+
+from mlx_taef.kernels._conversion import DiffusersRemap
+from mlx_taef.kernels._types import (
+    ArchSpec,
+    LatentSpec,
+    MfluxBinding,
+    ModelKernel,
+    UnpackContext,
+    WeightSource,
+)
+
+TAESD2D = ArchSpec(name="taesd2d")
+
+
+def unpack_flux1_latent(latent: mx.array, ctx: UnpackContext) -> mx.array:
+    """Unpack mflux's packed FLUX.1 in-loop latent into NHWC (B, lh*2, lw*2, 16) for TAEF1.
+
+    mflux's in-loop FLUX.1 latent is PACKED `(B, lh*lw, 64)` (the denoiser operates on the
+    packed form; mflux only unpacks after the loop). The pre-refactor callback's
+    `shape[1] == 16` check never matched and fed the packed latent straight to TAEF1 -> a
+    broken preview. This mirrors mflux `FluxLatentCreator.unpack_latents` EXACTLY
+    (reshape `(1, lh, lw, 16, 2, 2)` -> transpose `(0,3,1,4,2,5)` -> `(1,16,lh*2,lw*2)`),
+    then NCHW->NHWC for TAEF1.
+    """
+    b, _, c = latent.shape
+    if c != 64:
+        raise ValueError(f"Expected 64-channel packed FLUX.1 latent, got {c}")
+    lh, lw = ctx.latent_height, ctx.latent_width
+    x = latent.reshape(b, lh, lw, 16, 2, 2)
+    x = x.transpose(0, 3, 1, 4, 2, 5)  # (b, 16, lh, 2, lw, 2)
+    x = x.reshape(b, 16, lh * 2, lw * 2)
+    return x.transpose(0, 2, 3, 1)  # NHWC for TAEF1
+
+
+def unpack_flux2_latent(latent: mx.array, ctx: UnpackContext) -> mx.array:
+    """Unpack mflux's packed FLUX.2 latent into NHWC (B, lh*2, lw*2, 32) for TAEF2.
+
+    BN denormalize (128-ch stats) + unpatchify + NCHW->NHWC. BN stats come from ctx; absent
+    -> identity BN. Transpose order matches the shipped pre-refactor unpack_flux2_latent.
+    """
+    b, _, c = latent.shape
+    if c != 128:
+        raise ValueError(f"Expected 128-channel packed FLUX.2 latent, got {c}")
+    lh, lw = ctx.latent_height, ctx.latent_width
+    latents = latent.reshape(b, lh, lw, c).transpose(0, 3, 1, 2)
+    if ctx.bn_mean is not None and ctx.bn_var is not None:
+        mean = ctx.bn_mean.reshape(1, -1, 1, 1)
+        std = mx.sqrt(ctx.bn_var.reshape(1, -1, 1, 1) + ctx.bn_eps)
+        latents = latents * std + mean
+    batch, _, h, w = latents.shape
+    latents = latents.reshape(batch, 32, 2, 2, h, w).transpose(0, 1, 4, 2, 5, 3)
+    latents = latents.reshape(batch, 32, h * 2, w * 2)
+    return latents.transpose(0, 2, 3, 1)
+
+
+TAEF1 = ModelKernel(
+    name="taef1",
+    arch=TAESD2D,
+    conversion=DiffusersRemap(),
+    latent=LatentSpec(channels=16),
+    source=WeightSource(repo="madebyollin/taef1", filename="diffusion_pytorch_model.safetensors"),
+    integration=MfluxBinding(
+        mflux_models=("flux1", "flux-dev", "flux-schnell"), unpack=unpack_flux1_latent
+    ),
+    memory_cap_hint_gb=1,
+)
+
+TAEF2 = ModelKernel(
+    name="taef2",
+    arch=TAESD2D,
+    conversion=DiffusersRemap(),
+    latent=LatentSpec(channels=32),
+    source=WeightSource(repo="madebyollin/taef2", filename="taef2.safetensors"),
+    integration=MfluxBinding(mflux_models=("flux2", "flux2-klein"), unpack=unpack_flux2_latent),
+    memory_cap_hint_gb=2,
+)

--- a/src/mlx_taef/kernels/sd.py
+++ b/src/mlx_taef/kernels/sd.py
@@ -1,0 +1,34 @@
+"""Stable Diffusion (SD1.x / SDXL) model kernels."""
+
+from mlx_taef.kernels._conversion import UpstreamTwoFile
+from mlx_taef.kernels._types import ArchSpec, LatentSpec, ModelKernel, WeightSource
+
+TAESD2D = ArchSpec(name="taesd2d")
+
+TAESD = ModelKernel(
+    name="taesd",
+    arch=TAESD2D,
+    conversion=UpstreamTwoFile(),
+    latent=LatentSpec(channels=4),
+    source=WeightSource(
+        repo="madebyollin/taesd",
+        decoder_filename="taesd_decoder.safetensors",
+        encoder_filename="taesd_encoder.safetensors",
+    ),
+    integration=None,
+    memory_cap_hint_gb=None,
+)
+
+TAESDXL = ModelKernel(
+    name="taesdxl",
+    arch=TAESD2D,
+    conversion=UpstreamTwoFile(),
+    latent=LatentSpec(channels=4),
+    source=WeightSource(
+        repo="madebyollin/taesdxl",
+        decoder_filename="taesdxl_decoder.safetensors",
+        encoder_filename="taesdxl_encoder.safetensors",
+    ),
+    integration=None,
+    memory_cap_hint_gb=None,
+)

--- a/src/mlx_taef/model.py
+++ b/src/mlx_taef/model.py
@@ -132,30 +132,14 @@ def make_decoder(config: TaesdVariantConfig) -> nn.Sequential:  # type: ignore[n
     Returns:
         `nn.Sequential` decoder ready for weight loading.
     """
-    mb = config.use_midblock_gn
-    layers: list[nn.Module] = [  # type: ignore[name-defined]
-        Clamp(),
-        make_conv(config.latent_channels, 64),
-        nn.ReLU(),  # type: ignore[attr-defined]
-        Block(64, 64, use_midblock_gn=mb),
-        Block(64, 64, use_midblock_gn=mb),
-        Block(64, 64, use_midblock_gn=mb),
-        nn.Upsample(scale_factor=2, mode="nearest"),  # type: ignore[attr-defined]
-        make_conv(64, 64, bias=False),
-        Block(64, 64),
-        Block(64, 64),
-        Block(64, 64),
-        nn.Upsample(scale_factor=2, mode="nearest"),  # type: ignore[attr-defined]
-        make_conv(64, 64, bias=False),
-        Block(64, 64),
-        Block(64, 64),
-        Block(64, 64),
-        nn.Upsample(scale_factor=2, mode="nearest"),  # type: ignore[attr-defined]
-        make_conv(64, 64, bias=False),
-        Block(64, 64),
-        make_conv(64, 3),
-    ]
-    return nn.Sequential(*layers)  # type: ignore[attr-defined]
+    from mlx_taef.kernels._arch import build_arch
+
+    return build_arch(
+        "taesd2d",
+        role="decoder",
+        latent_channels=config.latent_channels,
+        midblock_gn=config.use_midblock_gn,
+    )
 
 
 def make_encoder(config: TaesdVariantConfig) -> nn.Sequential:  # type: ignore[name-defined]
@@ -173,25 +157,14 @@ def make_encoder(config: TaesdVariantConfig) -> nn.Sequential:  # type: ignore[n
     Returns:
         `nn.Sequential` encoder ready for weight loading.
     """
-    mb = config.use_midblock_gn
-    layers: list[nn.Module] = [  # type: ignore[name-defined]
-        make_conv(3, 64),
-        Block(64, 64),
-        make_conv(64, 64, stride=2, bias=False),
-        Block(64, 64),
-        Block(64, 64),
-        Block(64, 64),
-        make_conv(64, 64, stride=2, bias=False),
-        Block(64, 64),
-        Block(64, 64),
-        Block(64, 64),
-        make_conv(64, 64, stride=2, bias=False),
-        Block(64, 64, use_midblock_gn=mb),
-        Block(64, 64, use_midblock_gn=mb),
-        Block(64, 64, use_midblock_gn=mb),
-        make_conv(64, config.latent_channels),
-    ]
-    return nn.Sequential(*layers)  # type: ignore[attr-defined]
+    from mlx_taef.kernels._arch import build_arch
+
+    return build_arch(
+        "taesd2d",
+        role="encoder",
+        latent_channels=config.latent_channels,
+        midblock_gn=config.use_midblock_gn,
+    )
 
 
 __all__ = ["Block", "Clamp", "make_conv", "make_decoder", "make_encoder"]

--- a/src/mlx_taef/variants.py
+++ b/src/mlx_taef/variants.py
@@ -1,41 +1,21 @@
-"""Variant configurations for the TAESD-family of tiny autoencoders.
+"""Back-compat shim. The source of truth moved to `mlx_taef.kernels`.
 
-Field reference:
-- `key_format`: "upstream" means the HF safetensors uses upstream Sequential keys
-  like "0.weight", "1.weight"; "diffusers" means the HF safetensors uses Diffusers
-  VAE keys like "encoder.layers.0.weight" and requires a +1 decoder index offset.
-- `arch_variant`: None | "flux_2" | "f32". "flux_2" enables midblock_gn pool
-  branches in three blocks of encoder and decoder. "f32" is reserved for
-  TAESANA (future).
-- `latent_magnitude`, `latent_shift`: from upstream TAESD.scale_latents /
-  unscale_latents.
-- `hf_filename` (Diffusers single-file format) vs `hf_decoder_filename` /
-  `hf_encoder_filename` (upstream two-file format) — depends on the actual
-  repo layout for each variant.
+Reconstructs the legacy `TaesdVariantConfig` view + `*_CONFIG` constants, `ALL_VARIANTS`,
+`VARIANTS`, and `get_memory_cap_hint` from the kernel registry so existing imports keep
+working. New code should import from `mlx_taef.kernels`.
 """
 
 import logging
 from dataclasses import dataclass
+
+from mlx_taef.kernels import KERNELS, MIDBLOCK_GN, ModelKernel
 
 logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
 class TaesdVariantConfig:
-    """Configuration for a single TAESD-family variant.
-
-    Attributes:
-        name: short identifier like "taef2".
-        latent_channels: latent channel count (4 for SD1/SDXL, 16 for FLUX.1, 32 for FLUX.2 Klein).
-        arch_variant: None for the standard arch, "flux_2" for TAEF2's midblock_gn, "f32" for TAESANA.
-        key_format: "upstream" (Sequential keys) or "diffusers" (requires remap).
-        hf_repo: e.g. "madebyollin/taef2".
-        hf_filename: filename within hf_repo when key_format == "diffusers" (single file).
-        hf_decoder_filename: decoder filename when key_format == "upstream".
-        hf_encoder_filename: encoder filename when key_format == "upstream".
-        latent_magnitude: scale factor for scale_latents/unscale_latents.
-        latent_shift: shift factor for scale_latents/unscale_latents.
-    """
+    """Legacy variant config view (derived from a ModelKernel)."""
 
     name: str
     latent_channels: int
@@ -55,51 +35,27 @@ class TaesdVariantConfig:
         return self.arch_variant == "flux_2"
 
 
-TAESD_CONFIG = TaesdVariantConfig(
-    name="taesd",
-    latent_channels=4,
-    arch_variant=None,
-    key_format="upstream",
-    hf_repo="madebyollin/taesd",
-    hf_filename=None,
-    hf_decoder_filename="taesd_decoder.safetensors",
-    hf_encoder_filename="taesd_encoder.safetensors",
-)
+def _from_kernel(k: ModelKernel) -> TaesdVariantConfig:
+    is_diffusers = k.source.filename is not None
+    return TaesdVariantConfig(
+        name=k.name,
+        latent_channels=k.latent.channels,
+        arch_variant="flux_2" if MIDBLOCK_GN.get(k.name, False) else None,
+        key_format="diffusers" if is_diffusers else "upstream",
+        hf_repo=k.source.repo,
+        hf_filename=k.source.filename,
+        hf_decoder_filename=k.source.decoder_filename,
+        hf_encoder_filename=k.source.encoder_filename,
+        latent_magnitude=k.latent.magnitude,
+        latent_shift=k.latent.shift,
+        memory_cap_hint_gb=k.memory_cap_hint_gb,
+    )
 
-TAESDXL_CONFIG = TaesdVariantConfig(
-    name="taesdxl",
-    latent_channels=4,
-    arch_variant=None,
-    key_format="upstream",
-    hf_repo="madebyollin/taesdxl",
-    hf_filename=None,
-    hf_decoder_filename="taesdxl_decoder.safetensors",
-    hf_encoder_filename="taesdxl_encoder.safetensors",
-)
 
-TAEF1_CONFIG = TaesdVariantConfig(
-    name="taef1",
-    latent_channels=16,
-    arch_variant=None,
-    key_format="diffusers",
-    hf_repo="madebyollin/taef1",
-    hf_filename="diffusion_pytorch_model.safetensors",
-    hf_decoder_filename=None,
-    hf_encoder_filename=None,
-    memory_cap_hint_gb=1,
-)
-
-TAEF2_CONFIG = TaesdVariantConfig(
-    name="taef2",
-    latent_channels=32,
-    arch_variant="flux_2",
-    key_format="diffusers",
-    hf_repo="madebyollin/taef2",
-    hf_filename="taef2.safetensors",
-    hf_decoder_filename=None,
-    hf_encoder_filename=None,
-    memory_cap_hint_gb=2,
-)
+TAESD_CONFIG = _from_kernel(KERNELS["taesd"])
+TAESDXL_CONFIG = _from_kernel(KERNELS["taesdxl"])
+TAEF1_CONFIG = _from_kernel(KERNELS["taef1"])
+TAEF2_CONFIG = _from_kernel(KERNELS["taef2"])
 
 ALL_VARIANTS: tuple[TaesdVariantConfig, ...] = (
     TAESD_CONFIG,
@@ -107,7 +63,6 @@ ALL_VARIANTS: tuple[TaesdVariantConfig, ...] = (
     TAEF1_CONFIG,
     TAEF2_CONFIG,
 )
-
 VARIANTS: dict[str, TaesdVariantConfig] = {v.name: v for v in ALL_VARIANTS}
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,3 +55,21 @@ def test_cli_bench_prints_decode_time(capsys: pytest.CaptureFixture[str]) -> Non
     assert rc == 0
     captured = capsys.readouterr()
     assert "decode median:" in captured.out
+
+
+def test_cli_sources_choices_from_registry_not_all_variants() -> None:
+    """Migration target: choices come from KERNELS; the legacy ALL_VARIANTS import is gone."""
+    import mlx_taef.cli as c
+
+    assert not hasattr(c, "ALL_VARIANTS")
+    assert hasattr(c, "KERNELS")
+
+
+def test_cli_convert_variant_choices_include_all_kernels(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit):
+        main(["convert", "--variant", "not-a-variant", "--dst", "/tmp/x.safetensors"])
+    err = capsys.readouterr().err
+    for name in ("taesd", "taesdxl", "taef1", "taef2"):
+        assert name in err

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,88 +1,44 @@
-"""Tests for HF Hub auto-download + cache."""
-
-from pathlib import Path
+"""Offline tests for download.get_or_convert: caching + role dispatch, no network."""
 
 import mlx.core as mx
-import pytest
+
+from mlx_taef import download
+from mlx_taef.kernels import get_kernel
 
 
-def test_get_or_convert_returns_cached_path_when_exists(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Second call should return cached path without re-running conversion."""
-    from mlx_taef import download
-    from mlx_taef.variants import TAEF2_CONFIG
+def _fake_convert_factory(calls):
+    def _fake(self, source, arch_module, *, role):
+        calls.append(role)
+        return {"w": mx.zeros((1,))}
 
+    return _fake
+
+
+def test_get_or_convert_caches_and_dispatches_role(monkeypatch, tmp_path):
     monkeypatch.setattr(download, "CACHE_ROOT", tmp_path)
-    fake_call_count = [0]
+    calls: list[str] = []
+    monkeypatch.setattr(
+        "mlx_taef.kernels._conversion.DiffusersRemap.convert", _fake_convert_factory(calls)
+    )
+    k = get_kernel("taef1")
 
-    def fake_converter(*, out_path: Path, config) -> None:
-        fake_call_count[0] += 1
-        out_path.write_bytes(b"fake")
+    p_dec = download.get_or_convert(k, role="decoder")
+    assert p_dec.exists()
+    assert calls == ["decoder"]
 
-    monkeypatch.setattr(download, "convert_hf_decoder_to_mlx", fake_converter)
+    calls.clear()
+    p_dec2 = download.get_or_convert(k, role="decoder")
+    assert p_dec2 == p_dec
+    assert calls == []
 
-    p1 = download.get_or_convert(TAEF2_CONFIG, role="decoder")
-    p2 = download.get_or_convert(TAEF2_CONFIG, role="decoder")
-
-    assert p1 == p2
-    assert fake_call_count[0] == 1, "Converter should be called exactly once"
-
-
-def test_get_or_convert_dispatches_role(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    from mlx_taef import download
-    from mlx_taef.variants import TAEF2_CONFIG
-
-    monkeypatch.setattr(download, "CACHE_ROOT", tmp_path)
-    calls = []
-
-    def fake_dec(*, out_path: Path, config) -> None:
-        calls.append(("decoder", out_path.name))
-        out_path.write_bytes(b"fake")
-
-    def fake_enc(*, out_path: Path, config) -> None:
-        calls.append(("encoder", out_path.name))
-        out_path.write_bytes(b"fake")
-
-    monkeypatch.setattr(download, "convert_hf_decoder_to_mlx", fake_dec)
-    monkeypatch.setattr(download, "convert_hf_encoder_to_mlx", fake_enc)
-
-    download.get_or_convert(TAEF2_CONFIG, role="decoder")
-    download.get_or_convert(TAEF2_CONFIG, role="encoder")
-
-    assert calls == [
-        ("decoder", "taef2_decoder.safetensors"),
-        ("encoder", "taef2_encoder.safetensors"),
-    ]
+    p_enc = download.get_or_convert(k, role="encoder")
+    assert p_enc != p_dec
+    assert calls == ["encoder"]
 
 
-def test_get_or_convert_rejects_invalid_role(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    from mlx_taef import download
-    from mlx_taef.variants import TAEF2_CONFIG
+def test_get_or_convert_rejects_bad_role(tmp_path, monkeypatch):
+    import pytest
 
     monkeypatch.setattr(download, "CACHE_ROOT", tmp_path)
     with pytest.raises(ValueError, match="role must be"):
-        download.get_or_convert(TAEF2_CONFIG, role="invalid")
-
-
-def test_from_pretrained_repo_id_mismatch_raises() -> None:
-    from mlx_taef import TAEF2
-
-    with pytest.raises(ValueError, match="repo_id mismatch"):
-        TAEF2.from_pretrained(repo_id="some/other-repo")
-
-
-@pytest.mark.network
-def test_from_pretrained_end_to_end(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Integration: full from_pretrained() against real HF download. Marked network."""
-    from mlx_taef import TAEF2, download
-
-    monkeypatch.setattr(download, "CACHE_ROOT", tmp_path)
-    model = TAEF2.from_pretrained(include_encoder=False)
-    assert model is not None
-    # Sanity: weights are actually loaded.
-    latent = mx.zeros((1, 8, 8, 32))
-    img = model.decode(latent)
-    assert img.shape == (1, 64, 64, 3)
+        download.get_or_convert(get_kernel("taef1"), role="bogus")

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -137,3 +137,10 @@ def test_mlx_teacache_not_installed_default_message_mentions_install_path() -> N
     assert "pip install" in msg
     assert "uv add" in msg
     assert "mlx-teacache" in msg
+
+
+def test_unknown_kernel_error_hierarchy():
+    from mlx_taef.errors import TaefError, UnknownKernelError
+
+    assert issubclass(UnknownKernelError, TaefError)
+    assert issubclass(UnknownKernelError, KeyError)

--- a/tests/test_integrations_kernels.py
+++ b/tests/test_integrations_kernels.py
@@ -1,0 +1,62 @@
+import mlx.core as mx
+import numpy as np
+import pytest
+
+from mlx_taef.kernels import UnpackContext, get_kernel
+from mlx_taef.kernels.flux import unpack_flux1_latent, unpack_flux2_latent
+
+
+def test_unpack_flux1_rejects_non_64_channels():
+    with pytest.raises(ValueError, match="64-channel"):
+        unpack_flux1_latent(mx.zeros((1, 16, 16)), UnpackContext(latent_height=4, latent_width=4))
+
+
+def test_unpack_flux1_matches_mflux_unpack_latents_oracle():
+    pytest.importorskip("mflux")
+    from mflux.models.flux.latent_creator.flux_latent_creator import FluxLatentCreator
+
+    lh = lw = 2
+    packed = mx.arange(lh * lw * 64).reshape(1, lh * lw, 64).astype(mx.float32)
+    oracle_nchw = FluxLatentCreator.unpack_latents(packed, height=lh * 16, width=lw * 16)
+    expected = np.array(mx.transpose(oracle_nchw, (0, 2, 3, 1)))  # NHWC
+    out = np.array(unpack_flux1_latent(packed, UnpackContext(latent_height=lh, latent_width=lw)))
+    assert out.shape == (1, lh * 2, lw * 2, 16)
+    assert np.array_equal(out, expected)
+
+
+def test_unpack_flux2_value_routing():
+    packed = mx.arange(128).reshape(1, 1, 128).astype(mx.float32)
+    out = np.array(unpack_flux2_latent(packed, UnpackContext(latent_height=1, latent_width=1)))
+    assert out.shape == (1, 2, 2, 32)
+    assert out[0, 0, 0, 0] == 0.0
+    assert out[0, 0, 1, 0] == 1.0
+    assert out[0, 1, 0, 0] == 2.0
+    assert out[0, 0, 0, 1] == 4.0
+
+
+def test_binding_dispatch_routes_each_model_to_its_unpack():
+    assert get_kernel("taef1").integration.unpack is unpack_flux1_latent
+    assert get_kernel("taef2").integration.unpack is unpack_flux2_latent
+
+
+def test_flux1_callback_end_to_end_writes_preview(monkeypatch, tmp_path):
+    pytest.importorskip("mflux")
+    from pathlib import Path
+
+    from mlx_taef.api import TAEF1
+    from mlx_taef.integrations.mflux import LivePreviewCallback
+
+    converted = Path(__file__).parent / "converted"
+    real = TAEF1.from_pretrained_local(converted / "taef1_decoder.safetensors")
+    monkeypatch.setattr(TAEF1, "from_pretrained", classmethod(lambda cls, **kw: real))
+
+    lh = lw = 8
+    cb = LivePreviewCallback(
+        variant="taef1", every=1, save_to=tmp_path / "p.png",
+        latent_height=lh, latent_width=lw,
+    )
+    packed = mx.random.normal((1, lh * lw, 64))
+    cb.call_in_loop(t=0, seed=0, prompt="x", latents=packed, config=None, time_steps=None)
+    out = tmp_path / "p.png"
+    assert out.exists()
+    assert out.stat().st_size > 0

--- a/tests/test_integrations_kernels.py
+++ b/tests/test_integrations_kernels.py
@@ -52,8 +52,11 @@ def test_flux1_callback_end_to_end_writes_preview(monkeypatch, tmp_path):
 
     lh = lw = 8
     cb = LivePreviewCallback(
-        variant="taef1", every=1, save_to=tmp_path / "p.png",
-        latent_height=lh, latent_width=lw,
+        variant="taef1",
+        every=1,
+        save_to=tmp_path / "p.png",
+        latent_height=lh,
+        latent_width=lw,
     )
     packed = mx.random.normal((1, lh * lw, 64))
     cb.call_in_loop(t=0, seed=0, prompt="x", latents=packed, config=None, time_steps=None)

--- a/tests/test_kernels_api.py
+++ b/tests/test_kernels_api.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+import mlx.core as mx
+import numpy as np
+
+from mlx_taef import TAEF1, TAEF2, TAESD, TAESDXL
+from mlx_taef.api import Taef
+from mlx_taef.kernels import get_kernel
+
+CONVERTED = Path(__file__).parent / "converted"
+
+
+def test_classes_bind_their_kernels():
+    assert TAESD._kernel is get_kernel("taesd")
+    assert TAEF1._kernel is get_kernel("taef1")
+    assert TAEF2._kernel is get_kernel("taef2")
+
+
+def test_channel_flow_decoder_in_dim_matches_latentspec():
+    for cls, ch in [(TAESD, 4), (TAESDXL, 4), (TAEF1, 16), (TAEF2, 32)]:
+        assert cls().decoder.layers[1].weight.shape[-1] == ch
+
+
+def test_scale_unscale_roundtrip_reads_kernel_latentspec():
+    for cls in (TAESD, TAEF1, TAEF2):
+        m = cls()
+        raw = mx.clip(mx.random.normal((1, 4, 4, m._kernel.latent.channels)), -2.9, 2.9)
+        assert np.allclose(
+            np.array(m.unscale_latents(m.scale_latents(raw))), np.array(raw), atol=1e-5
+        )
+
+
+def test_from_kernel_binds_passed_kernel_not_class_default():
+    k = get_kernel("taef2")
+    m = Taef.from_kernel(k, decoder_path=CONVERTED / "taef2_decoder.safetensors")
+    assert m._kernel is k
+    assert m.decoder.layers[1].weight.shape[-1] == 32
+    assert m.decode(mx.zeros((1, 8, 8, 32))).shape == (1, 64, 64, 3)

--- a/tests/test_kernels_arch.py
+++ b/tests/test_kernels_arch.py
@@ -1,0 +1,31 @@
+from mlx_taef.kernels._arch import ARCH_BUILDERS, build_arch
+
+
+def test_taesd2d_registered():
+    assert "taesd2d" in ARCH_BUILDERS
+
+
+def test_build_decoder_channels_flow_from_latentspec():
+    dec16 = build_arch("taesd2d", role="decoder", latent_channels=16, midblock_gn=False)
+    assert dec16.layers[1].weight.shape[-1] == 16
+    dec32 = build_arch("taesd2d", role="decoder", latent_channels=32, midblock_gn=True)
+    assert dec32.layers[1].weight.shape[-1] == 32
+
+
+def test_build_encoder_emits_requested_latent_channels():
+    enc = build_arch("taesd2d", role="encoder", latent_channels=16, midblock_gn=False)
+    assert enc.layers[-1].weight.shape[0] == 16
+
+
+def test_midblock_gn_toggles_pool_branch():
+    with_gn = build_arch("taesd2d", role="decoder", latent_channels=32, midblock_gn=True)
+    without = build_arch("taesd2d", role="decoder", latent_channels=32, midblock_gn=False)
+    assert with_gn.layers[3].pool is not None
+    assert without.layers[3].pool is None
+
+
+def test_unknown_arch_raises():
+    import pytest
+
+    with pytest.raises(KeyError, match="unknown arch"):
+        build_arch("nope", role="decoder", latent_channels=16, midblock_gn=False)

--- a/tests/test_kernels_conversion.py
+++ b/tests/test_kernels_conversion.py
@@ -1,0 +1,46 @@
+import numpy as np
+
+from mlx_taef.convert import _flatten_module_param_shapes
+from mlx_taef.kernels._arch import build_arch
+from mlx_taef.kernels._conversion import DiffusersRemap, UpstreamTwoFile
+
+
+def _mlx_to_sequential(mlx_key: str) -> str:
+    # Inverse of convert._sequential_key_to_mlx: drop the "layers" path segments.
+    return ".".join(p for p in mlx_key.split(".") if p != "layers")
+
+
+def _synth_sequential_source(arch_module) -> dict[str, np.ndarray]:
+    # 4D conv weights stored NCHW (out,in,kh,kw) so the strategy's NHWC transpose runs.
+    expected = _flatten_module_param_shapes(arch_module)
+    src: dict[str, np.ndarray] = {}
+    for mlx_key, shape in expected.items():
+        seq_key = _mlx_to_sequential(mlx_key)
+        if len(shape) == 4:
+            o, kh, kw, i = shape
+            src[seq_key] = np.zeros((o, i, kh, kw), dtype=np.float32)
+        else:
+            src[seq_key] = np.zeros(shape, dtype=np.float32)
+    return src
+
+
+def test_diffusers_remap_round_trips_to_arch_shapes_offline(monkeypatch):
+    decoder = build_arch("taesd2d", role="decoder", latent_channels=16, midblock_gn=False)
+    expected = _flatten_module_param_shapes(decoder)
+    src = _synth_sequential_source(decoder)
+    strat = DiffusersRemap()
+    monkeypatch.setattr(strat, "_load_raw", lambda source, role: src)
+    out = strat.convert(source=object(), arch_module=decoder, role="decoder")  # type: ignore[arg-type]
+    assert set(out) == set(expected)
+    for k, shape in expected.items():
+        assert tuple(out[k].shape) == shape
+
+
+def test_upstream_two_file_round_trips_offline(monkeypatch):
+    encoder = build_arch("taesd2d", role="encoder", latent_channels=4, midblock_gn=False)
+    expected = _flatten_module_param_shapes(encoder)
+    src = _synth_sequential_source(encoder)
+    strat = UpstreamTwoFile()
+    monkeypatch.setattr(strat, "_load_raw", lambda source, role: src)
+    out = strat.convert(source=object(), arch_module=encoder, role="encoder")  # type: ignore[arg-type]
+    assert set(out) == set(expected)

--- a/tests/test_kernels_registry.py
+++ b/tests/test_kernels_registry.py
@@ -1,0 +1,36 @@
+import pytest
+
+from mlx_taef.errors import TaefError, UnknownKernelError
+from mlx_taef.kernels import KERNELS, get_kernel
+
+
+def test_registry_has_exactly_the_four_migrated_kernels():
+    assert set(KERNELS) == {"taesd", "taesdxl", "taef1", "taef2"}
+
+
+def test_kernel_names_byte_identical_and_fixtures_resolve():
+    from pathlib import Path
+
+    converted = Path(__file__).parent / "converted"
+    for name in ("taesd", "taesdxl", "taef1", "taef2"):
+        assert get_kernel(name).name == name
+        assert (converted / f"{name}_decoder.safetensors").exists()
+
+
+def test_get_kernel_unknown_raises_taef_error():
+    with pytest.raises(TaefError, match="unknown kernel"):
+        get_kernel("nope")
+    with pytest.raises(UnknownKernelError):
+        get_kernel("nope")
+
+
+def test_taef1_and_zimage_would_share_cache_key():
+    taef1 = get_kernel("taef1")
+    assert taef1.source.cache_key(role="decoder") == (
+        "madebyollin_taef1__diffusion_pytorch_model.safetensors__decoder"
+    )
+
+
+def test_registry_is_immutable():
+    with pytest.raises(TypeError):
+        KERNELS["x"] = object()  # type: ignore[index]

--- a/tests/test_kernels_types.py
+++ b/tests/test_kernels_types.py
@@ -1,0 +1,76 @@
+import mlx.core as mx
+import pytest
+
+from mlx_taef.kernels._types import (
+    ArchSpec,
+    LatentSpec,
+    MfluxBinding,
+    ModelKernel,
+    UnpackContext,
+    WeightSource,
+)
+
+
+def test_latentspec_defaults_and_frozen():
+    ls = LatentSpec(channels=16)
+    assert (ls.channels, ls.magnitude, ls.shift, ls.downsample) == (16, 3.0, 0.5, 8)
+    with pytest.raises((AttributeError, TypeError)):
+        ls.channels = 32  # type: ignore[misc]
+
+
+def test_weightsource_cache_key_always_includes_role():
+    diffusers = WeightSource(
+        repo="madebyollin/taef1", filename="diffusion_pytorch_model.safetensors"
+    )
+    assert (
+        diffusers.cache_key(role="decoder")
+        == "madebyollin_taef1__diffusion_pytorch_model.safetensors__decoder"
+    )
+    assert (
+        diffusers.cache_key(role="encoder")
+        == "madebyollin_taef1__diffusion_pytorch_model.safetensors__encoder"
+    )
+    assert diffusers.cache_key(role="decoder") != diffusers.cache_key(role="encoder")
+    upstream = WeightSource(
+        repo="madebyollin/taesd",
+        decoder_filename="taesd_decoder.safetensors",
+        encoder_filename="taesd_encoder.safetensors",
+    )
+    assert (
+        upstream.cache_key(role="decoder")
+        == "madebyollin_taesd__taesd_decoder.safetensors__decoder"
+    )
+    assert (
+        upstream.cache_key(role="encoder")
+        == "madebyollin_taesd__taesd_encoder.safetensors__encoder"
+    )
+
+
+def test_archspec_is_name_only():
+    arch = ArchSpec(name="taesd2d")
+    assert arch.name == "taesd2d"
+    assert not hasattr(arch, "latent_channels")
+    assert not hasattr(arch, "midblock_gn")
+
+
+def test_unpackcontext_holds_optional_bn_stats_and_eps():
+    ctx = UnpackContext(latent_height=32, latent_width=32)
+    assert ctx.bn_mean is None
+    assert ctx.bn_var is None
+    assert ctx.bn_eps == 1e-4
+
+
+def test_modelkernel_composes_strategies():
+    k = ModelKernel(
+        name="demo",
+        arch=ArchSpec(name="taesd2d"),
+        conversion=object(),
+        latent=LatentSpec(channels=16),
+        source=WeightSource(repo="r", filename="f"),
+        integration=MfluxBinding(mflux_models=("demo",), unpack=lambda latent, ctx: latent),
+        memory_cap_hint_gb=1,
+    )
+    assert k.name == "demo"
+    assert k.latent.channels == 16
+    out = k.integration.unpack(mx.zeros((1,)), UnpackContext(latent_height=1, latent_width=1))
+    assert out.shape == (1,)

--- a/tests/test_refactor_guards.py
+++ b/tests/test_refactor_guards.py
@@ -1,0 +1,49 @@
+"""Guard: the v0.3.0 kernel refactor is zero-behavior-change vs the base branch.
+
+It must not modify committed reference fixtures, converted weights, or the fixture manifest —
+those are the bit-exact parity oracle. A diff against the merge-base catches any such change.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+PROTECTED = ("tests/reference", "tests/converted", "tests/fixtures.toml")
+
+
+def _base_ref() -> str | None:
+    for ref in ("origin/main", "main"):
+        r = subprocess.run(
+            ["git", "rev-parse", "--verify", "-q", ref],
+            cwd=REPO,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if r.returncode == 0:
+            return ref
+    return None
+
+
+def test_phase1_does_not_modify_committed_fixtures():
+    base = _base_ref()
+    if base is None:
+        pytest.skip("no origin/main or main ref to diff against")
+    merge_base = subprocess.run(
+        ["git", "merge-base", base, "HEAD"],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    changed = subprocess.run(
+        ["git", "diff", "--name-only", f"{merge_base}...HEAD"],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.splitlines()
+    touched = [f for f in changed if any(f.startswith(p) for p in PROTECTED)]
+    assert touched == [], f"refactor must not modify committed fixtures, but changed: {touched}"

--- a/tests/test_variants_shim.py
+++ b/tests/test_variants_shim.py
@@ -1,0 +1,36 @@
+"""Back-compat shim tests: legacy `mlx_taef.variants` surface derived from kernels."""
+
+import pytest
+
+import mlx_taef.variants as v
+from mlx_taef.kernels import get_kernel
+
+
+def test_legacy_constants_present_and_derived_from_kernels():
+    assert v.TAEF2_CONFIG.latent_channels == 32
+    assert v.TAEF2_CONFIG.arch_variant == "flux_2"
+    assert v.TAEF2_CONFIG.use_midblock_gn is True
+    assert v.TAEF2_CONFIG.key_format == "diffusers"
+    assert v.TAEF2_CONFIG.hf_repo == get_kernel("taef2").source.repo  # derived, not hardcoded
+    assert v.TAESD_CONFIG.key_format == "upstream"
+    assert v.TAESD_CONFIG.hf_decoder_filename == "taesd_decoder.safetensors"
+
+
+def test_non_flux2_variants_have_no_arch_variant():
+    # Guards against a MIDBLOCK_GN edit silently flipping a non-taef2 variant.
+    for name in ("taesd", "taesdxl", "taef1"):
+        cfg = getattr(v, f"{name.upper()}_CONFIG")
+        assert cfg.arch_variant is None
+        assert cfg.use_midblock_gn is False
+
+
+def test_all_variants_and_dict_present():
+    assert len(v.ALL_VARIANTS) == 4
+    assert set(v.VARIANTS) == {"taesd", "taesdxl", "taef1", "taef2"}
+
+
+def test_get_memory_cap_hint_reexported():
+    assert v.get_memory_cap_hint("taef2") == 2
+    assert v.get_memory_cap_hint("taesd") is None
+    with pytest.raises(KeyError, match="unknown variant"):
+        v.get_memory_cap_hint("nope")


### PR DESCRIPTION
## Summary
Refactors the four variants into composable model **kernels** (`mlx_taef.kernels`) so new
models become self-contained additions. Zero public API change — gated by the existing
bit-exact parity/SSIM fixtures. Also fixes a confirmed FLUX.1 live-preview unpack bug.

## What changed
- New `kernels/` package: a frozen `ModelKernel` over `ArchSpec` / `ConversionStrategy`
  (owns the full HF→MLX conversion) / `LatentSpec` / `WeightSource` / `MfluxBinding`.
- `Taef` reads its kernel; `Taef.from_kernel(...)` added; the four public classes unchanged.
- Converted-weights cache keyed on weight identity (repo + filename + role), so models that
  share upstream weights share one cache entry. 0.2.x caches rebuild once on first run.
- `LivePreviewCallback` dispatches the preview unpack via the kernel binding — fixes the
  FLUX.1 packed-latent bug (was `# pragma: no cover`; now value-tested against mflux's own
  `unpack_latents`). `unpack_flux2_latent` keeps its keyword signature via a wrapper.
- `variants.py` is now a complete back-compat shim over the registry.

## Test plan
- Whole suite green; no committed fixture bytes changed (guarded by
  `tests/test_refactor_guards.py`). Coverage 97%.
- New offline tests: kernel types (role-keyed cache), arch channel-flow, conversion
  round-trip (diffusers + upstream), registry exact-set + named error, per-kernel
  scale/unscale, `from_kernel` binding, FLUX.1 unpack vs mflux oracle, FLUX.2 value
  routing, binding dispatch, FLUX.1 callback end-to-end, shim identity + derivation.
- `uv run pytest` → 199 passed, 14 skipped; `ruff check` / `ruff format --check` / `mypy --strict` clean.

## Not in this PR
Z-Image (v0.4.0) and Qwen-Image (v0.5.0) land on later branches per the design spec.