### PR TITLE
fix: actually ignore docs/superpowers (leading-space pattern was a no-op)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,6 @@ tests/reference/*.pt
 
 # hatch-vcs auto-generated
 src/mlx_taef/_version.py
-  docs/superpowers/
+
+# working-state docs (specs/plans/reviews) live at the workspace root, never here
+docs/superpowers/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ exclude = [
   ".github/",
   ".hypothesis/",
   ".pre-commit-config.yaml",
+  "docs/superpowers/",
   "notes/",
   "tests/_third_party/",
   "tests/converted/",


### PR DESCRIPTION
The `.gitignore` line meant to keep working-state docs out of the repo was indented:

```
  docs/superpowers/
```

Git treats leading whitespace as part of the pattern, so it matched nothing — `git check-ignore docs/superpowers/x.md` returned no match. Anything written under `docs/superpowers/` in this repo would have been committable, contradicting the workspace convention that those docs live only at the workspace root.

## Fix
- De-indent the pattern so it actually ignores `docs/superpowers/` (verified: `git check-ignore` now matches).
- Move it out from under the misleading `# hatch-vcs auto-generated` comment into its own comment.
- Add `docs/superpowers/` to the `[tool.hatch.build.targets.sdist]` exclude so it can't leak into the published sdist either.

## Scope / risk
Repo hygiene only — no source, no tests, no runtime behavior. `pyproject.toml` still parses and builds (verified).