### PR TITLE
chore: ignore CLAUDE.md via tracked .gitignore (match sibling repos)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ src/mlx_taef/_version.py
 
 # working-state docs (specs/plans/reviews) live at the workspace root, never here
 docs/superpowers/
+
+# per-repo Claude guidance — local-only working state, never committed
+/CLAUDE.md


### PR DESCRIPTION
Standardizes how the local-only per-repo `CLAUDE.md` is kept out of git. mlx-teacache and mlx-model-doctor ignore it with a `/CLAUDE.md` line in their tracked `.gitignore`; mlx-taef was using `.git/info/exclude`. This adds the same tracked line so all repos match. The `CLAUDE.md` content is never committed either way — only the ignore entry is.

The redundant `.git/info/exclude` entry will be dropped locally after merge to avoid a window where the file is briefly un-ignored on `main`.

Scope: repo hygiene only — one `.gitignore` line. No source, tests, or runtime change.