### PR TITLE
Use an absolute logo URL so the README renders on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # mlx-taef
 
 <p align="center">
-  <img src="docs/assets/mlx-taef-logo.png" alt="mlx-taef" width="100%">
+  <img src="https://raw.githubusercontent.com/IonDen/mlx-taef/main/docs/assets/mlx-taef-logo.png" alt="mlx-taef" width="100%">
 </p>
 
 [![PyPI version](https://img.shields.io/pypi/v/mlx-taef.svg)](https://pypi.org/project/mlx-taef/)


### PR DESCRIPTION
## What
Change the README header logo `<img src>` from the repo-relative path `docs/assets/mlx-taef-logo.png` to the absolute URL `https://raw.githubusercontent.com/IonDen/mlx-taef/main/docs/assets/mlx-taef-logo.png`.

## Why
PyPI's long-description renderer does not resolve repo-relative image paths, so the logo rendered blank on the PyPI project page (GitHub resolved it fine). An absolute raw URL renders on both. The fix takes effect on the next published release, because the long description is baked into each release's metadata at build time.

## Test plan
- README still renders on GitHub with the logo (absolute URL resolves there too).
- No code paths touched; CI unaffected.