### PR TITLE
Declare core metadata 2.4 so the v0.8.1 release can publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,15 @@ jobs:
         run: uv run ruff check .
       - name: Ruff format check
         run: uv run ruff format --check .
+      - name: Build distributions
+        # hatch-vcs needs a version; the shallow checkout has no tags to derive one from.
+        run: uv build
+        env:
+          SETUPTOOLS_SCM_PRETEND_VERSION: "0.0.0"
+      - name: Check distributions with the release action's twine
+        # twine is pinned to the version hynek/build-and-inspect-python-package@v2 bundles,
+        # so a metadata/tooling mismatch fails here instead of on the tag push.
+        run: uvx twine==6.2.0 check --strict dist/*
 
   typecheck:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ mflux 0.19.x compatibility.
 - mflux 0.19 points its `qwen-image` model at the newer `Qwen/Qwen-Image-2512` checkpoint. Its
   VAE weights are byte-identical to Qwen-Image's, so `variant="qwen-image"` previews it
   unchanged.
+- Built distributions now declare core metadata version 2.4. The current hatchling emits 2.5,
+  which the release workflow's twine rejected, so the first v0.8.1 tag never reached PyPI. CI
+  now builds the wheel and sdist and runs the same `twine check --strict` on every pull
+  request.
 
 ## [0.8.0] - 2026-08-09
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,8 +123,12 @@ version-file = "src/mlx_taef/_version.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/mlx_taef"]
+# hatchling >= 1.32 emits Metadata-Version 2.5, which the release workflow's twine (6.2.0,
+# bundled by the build action) rejects; 2.4 is read by every tool in the release path.
+core-metadata-version = "2.4"
 
 [tool.hatch.build.targets.sdist]
+core-metadata-version = "2.4"
 # Allowlist: ship only the source package, user-facing docs, examples, and license.
 # Everything else stays out by construction — the test suite (its large parity fixtures
 # under tests/converted/ and tests/reference/ are excluded, so the tests can't run from an

--- a/tests/test_ci_config.py
+++ b/tests/test_ci_config.py
@@ -22,6 +22,33 @@ def _pyproject() -> dict:
     return tomllib.loads(_PYPROJECT.read_text())
 
 
+def test_built_distributions_declare_core_metadata_2_4() -> None:
+    """The v0.8.1 tag push failed to publish: hatchling 1.32 emits Metadata-Version 2.5 and
+    the release workflow's `twine check --strict` (twine 6.2.0, bundled by the build action)
+    rejects it. Pinning the emitted core-metadata version to 2.4 keeps the wheel and sdist
+    readable by every tool in the release path. The one-line bug this catches: dropping
+    `core-metadata-version` from either hatch build target."""
+    targets = _pyproject()["tool"]["hatch"]["build"]["targets"]
+    assert targets["wheel"]["core-metadata-version"] == "2.4"
+    assert targets["sdist"]["core-metadata-version"] == "2.4"
+
+
+def test_ci_lint_job_checks_a_built_wheel_with_the_release_twine() -> None:
+    """The metadata/tooling mismatch was only ever exercised at tag time. The lint job must
+    build the distributions and run the same `twine check --strict` the release action runs,
+    with twine pinned to the version that action bundles, so the mismatch fails a pull
+    request instead of a release. The one-line bug this catches: removing the check step or
+    unpinning twine to whatever is newest (which would pass while the release tooling fails)."""
+    workflow = _CI_WORKFLOW.read_text()
+    assert "run: uv build" in workflow
+    check_lines = [
+        line.strip() for line in workflow.splitlines() if "twine" in line and "check" in line
+    ]
+    assert len(check_lines) == 1
+    assert "twine==6.2.0" in check_lines[0]
+    assert "check --strict dist/*" in check_lines[0]
+
+
 def test_ci_uv_sync_commands_are_frozen() -> None:
     workflow = _CI_WORKFLOW.read_text()
     sync_commands = [line.strip() for line in workflow.splitlines() if "run: uv sync" in line]


### PR DESCRIPTION
## What

The `v0.8.1` tag push (PR #38) failed in the Release workflow before anything reached PyPI: `hynek/build-and-inspect-python-package@v2` runs `twine check --strict` with the twine 6.2.0 it bundles, and that twine rejects the `Metadata-Version: 2.5` the current hatchling (1.32) emits (`InvalidDistribution: '2.5' is not a valid metadata version`). PyPI is still on 0.8.0 with the old `mflux<0.19` pin, so the mflux 0.19 crash fix is not yet installable.

## How

- `core-metadata-version = "2.4"` on the hatchling wheel and sdist targets. Verified locally: the rebuilt wheel and sdist declare 2.4 and pass `twine check --strict` under both twine 6.2.0 (what the action bundles) and 7.0.0 (which added 2.5 support).
- The lint job now builds both distributions and runs the same check with twine pinned to the action's version, so a metadata/tooling mismatch fails a pull request instead of a tag push. Two tests in `tests/test_ci_config.py` pin the configuration.
- One CHANGELOG line under 0.8.1.

After merge, the `v0.8.1` tag needs to be moved to the new merge commit and pushed again; the original tag was never published (no PyPI upload, no GitHub Release), so nothing downstream references it.